### PR TITLE
Reaftor/recommend

### DIFF
--- a/src/main/java/core/domain/user/entity/User.java
+++ b/src/main/java/core/domain/user/entity/User.java
@@ -91,6 +91,9 @@ public class User {
     @Column(name = "apple_refresh_token")
     private String appleRefreshToken;
 
+    @Column(name = "last_seen_at")
+    private Instant lastSeenAt;
+
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Notification> notifications = new ArrayList<>();
 
@@ -208,7 +211,9 @@ public class User {
         if (notBlank(socialId)) this.socialId = socialId;
         touchUpdatedAt();
     }
-
+    public void updateLastSeenAt() {
+        this.lastSeenAt = Instant.now();
+    }
     public void updateCreatedAt(Instant createdAt) {
         this.createdAt = createdAt;
     }

--- a/src/main/java/core/domain/user/repository/BlockRepository.java
+++ b/src/main/java/core/domain/user/repository/BlockRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface BlockRepository extends JpaRepository<BlockUser, Long> {
 
@@ -32,4 +33,16 @@ public interface BlockRepository extends JpaRepository<BlockUser, Long> {
     @Modifying
     @Query("delete from BlockUser b where b.user = :user or b.blocked = :user")
     void deleteAllByUserOrBlocked(@Param("user") User user);
+
+    /**
+     * 특정 사용자와 관련된 모든 차단 관계의 상대방 ID를 조회합니다.
+     * 1. 내가 다른 사람을 차단한 경우 (나는 'user', 상대방은 'blocked')
+     * 2. 다른 사람이 나를 차단한 경우 (나는 'blocked', 상대방은 'user')
+     * @param userId 기준 사용자의 ID (meId)
+     * @return 차단 관계에 있는 모든 상대방 사용자 ID Set
+     */
+    @Query("SELECT b.blocked.id FROM BlockUser b WHERE b.user.id = :userId " +
+            "UNION " +
+            "SELECT b.user.id FROM BlockUser b WHERE b.blocked.id = :userId")
+    Set<Long> findAllBlockedUserIds(@Param("userId") Long userId);
 }

--- a/src/main/java/core/domain/user/repository/FollowRepository.java
+++ b/src/main/java/core/domain/user/repository/FollowRepository.java
@@ -12,26 +12,17 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 
 @Repository
 public interface FollowRepository extends JpaRepository<Follow,Long> {
-    // 특정 사용자가 다른 사용자에게 보낸 팔로우 요청(PENDING 상태)이 있는지 확인
-    Optional<Follow> findByUserAndFollowingAndStatus(User user, User following, FollowStatus status);
-
-    // 팔로우 관계를 follower ID와 following ID로 찾습니다.
-    Optional<Follow> findByUserIdAndFollowingId(Long userId, Long followingId);
-
-    // 팔로우 관계를 follower ID와 following ID, 그리고 특정 상태(status)로 찾습니다.
-    Optional<Follow> findByUserIdAndFollowingIdAndStatus(Long userId, Long followingId, FollowStatus status);
     /**
      기존 메서드: 내가 팔로우하는 사람들을 조회 (보낸사람 조회)
      */
     @Query("SELECT f FROM Follow f JOIN FETCH f.following WHERE f.user = :user AND f.status = :status")
     List<Follow> findByUserAndStatus(@Param("user") User user, @Param("status") FollowStatus status);
 
-
-    // 2. 내가 보낸 팔로우 요청 중 PENDING, ACCEPTED 상태
     @Query("SELECT f FROM Follow f " +
             "WHERE f.user.id = :userId  " +
             "AND f.status IN (:statuses)")
@@ -51,7 +42,6 @@ public interface FollowRepository extends JpaRepository<Follow,Long> {
      **/
     Optional<Follow> findByUserAndFollowing(User user, User following);
 
-    // Correctly finds a Follow entity by the IDs of the 'user' and 'following' objects
     Optional<Follow> findByUser_IdAndFollowing_IdAndStatus(Long userId, Long followingId, FollowStatus status);
     /**
      * 특정 사용자와 관련된 모든 팔로우 관계를 삭제합니다.
@@ -68,9 +58,17 @@ public interface FollowRepository extends JpaRepository<Follow,Long> {
     List<Follow> findAllAcceptedFollowsByUserId(@Param("userId") Long userId,
                                                 @Param("status") FollowStatus status);
 
-    // 내가 보낸 PENDING 요청 수
     long countByUserIdAndStatus(Long userId, FollowStatus status);
 
-    // 내가 받은 PENDING 요청 수
     long countByFollowingIdAndStatus(Long followingId, FollowStatus status);
+    /**
+     * 특정 사용자가 팔로우 요청을 보냈거나(PENDING) 이미 친구 관계(ACCEPTED)인
+     * 모든 다른 사용자의 ID를 조회합니다.
+     * @param userId 팔로워의 ID (meId)
+     * @param statuses 추천에서 제외할 팔로우 상태 목록
+     * @return 추천에서 제외해야 할 사용자 ID Set
+     */
+    @Query("SELECT f.following.id FROM Follow f " +
+            "WHERE f.user.id = :userId AND f.status IN :statuses") // [수정] 문자열 대신 파라미터 사용
+    Set<Long> findFollowingIdsByUserId(@Param("userId") Long userId, @Param("statuses") List<FollowStatus> statuses);
 }

--- a/src/main/java/core/domain/user/repository/UserRepository.java
+++ b/src/main/java/core/domain/user/repository/UserRepository.java
@@ -9,6 +9,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -20,35 +22,13 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByName(String name);
 
-    long countByIdIn(Set<Long> allParticipantIds);
-
-    @Query("SELECT u FROM User u WHERE u.firstName = :firstName AND u.lastName = :lastName")
-    Optional<User> findByFirstAndLastName(@Param("firstName") String firstName,
-                                          @Param("lastName") String lastName);
-
-    @Query("SELECT u FROM User u WHERE u.id != :meId")
-    Page<User> findCandidatesExcluding(Long meId, Pageable pageable);
-    Optional<User> getUserById(Long id);
-
-    @Query("SELECT u FROM User u WHERE u.id != :meId AND u.purpose IS NOT NULL AND u.country IS NOT NULL AND u.language IS NOT NULL AND u.hobby IS NOT NULL")
-    Page<User> findPageNullMemberAndMember(@Param("meId") Long meId, Pageable pageable);
-
-    /**
-     * QueryDSL 수정이 필요할듯
-     */
-
-//    @Query("SELECT u FROM User u " +
-//            "JOIN Follow f ON (f.user.id = u.id AND f.following.id = :currentUserId) " +
-//            "OR (f.following.id = u.id AND f.user.id = :currentUserId) " +
-//            "WHERE f.status = 'ACCEPTED' AND " +
-//            "(:firstName IS NULL OR LOWER(u.firstName) LIKE CONCAT('%', LOWER(:firstName), '%')) AND " +
-//            "(:lastName IS NULL OR LOWER(u.lastName) LIKE CONCAT('%', LOWER(:lastName), '%'))")
-//    List<User> findAcceptedFriendsByFirstAndLastName(
-//            @Param("currentUserId") Long currentUserId,
-//            @Param("firstName") String firstName,
-//            @Param("lastName") String lastName
-//    );
-
     boolean existsByEmail(String email);
+
+    @Query("SELECT u FROM User u WHERE u.id NOT IN :excludeIds " +
+            "AND u.purpose IS NOT NULL AND u.purpose <> '' " +
+            "AND u.country IS NOT NULL AND u.country <> '' " +
+            "AND u.birthdate IS NOT NULL AND u.birthdate <> '' " +
+            "AND u.language IS NOT NULL AND u.language <> ''")
+    List<User> findFullProfiledRecommendationCandidates(@Param("excludeIds") Collection<Long> excludeIds);
 
 }

--- a/src/main/java/core/domain/user/service/ContentBasedRecommender.java
+++ b/src/main/java/core/domain/user/service/ContentBasedRecommender.java
@@ -1,10 +1,12 @@
 package core.domain.user.service;
 
+import core.domain.user.repository.FollowRepository;
 import core.domain.user.dto.UserUpdateDTO;
 import core.domain.user.entity.User;
 import core.domain.user.repository.BlockRepository;
 import core.domain.user.repository.UserRepository;
 import core.global.enums.ErrorCode;
+import core.global.enums.FollowStatus;
 import core.global.enums.ImageType;
 import core.global.exception.BusinessException;
 import core.global.image.repository.ImageRepository;
@@ -12,15 +14,14 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.Period;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -31,21 +32,17 @@ public class ContentBasedRecommender {
 
     private final UserRepository userRepository;
     private final ImageRepository imageRepository;
-    private static final double W_PURPOSE = 0.4;
-    private static final double W_COUNTRY = 0.2;
-    private static final double W_AGE = 0.3;   // 너가 바꾼 가중치 유지
-    private static final double W_LANG = 0.1;  // 너가 바꾼 가중치 유지
     private final BlockRepository blockRepository;
-    /**
-     랜덤 랭킹용 파라미터 (원하면 @Value 로 빼서 설정 가능)
-     * POOL_MULTIPLIER = 5;
-     * (limit * 5) 풀에서 추출
-     * MIN_POOL:최소 풀 사이즈
-     * TEMPERATURE: 클수록 랜덤성 증가
-     */
-    private static final int   POOL_MULTIPLIER = 2;
-    private static final int   MIN_POOL       = 2;
-    private static final double TEMPERATURE   = 0.1;
+    private final FollowRepository followRepository;
+
+    private static final double W_PURPOSE   = 0.35;
+    private static final double W_COUNTRY   = 0.15;
+    private static final double W_AGE       = 0.25;
+    private static final double W_LANG      = 0.10;
+    private static final double W_ACTIVITY  = 0.15;
+
+    private static final double TEMPERATURE = 0.7;
+    private static final double ACTIVITY_SCORE_HALF_LIFE_DAYS = 7.0;
 
     private static final java.security.SecureRandom RAND = new java.security.SecureRandom();
 
@@ -54,51 +51,36 @@ public class ContentBasedRecommender {
         User me = userRepository.findById(meId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
+        List<FollowStatus> statusesToExclude = List.of(FollowStatus.PENDING, FollowStatus.ACCEPTED);
+        Set<Long> followingIds = followRepository.findFollowingIdsByUserId(meId, statusesToExclude);
+        Set<Long> blockedIds = blockRepository.findAllBlockedUserIds(meId);
+
+        Set<Long> excludeIds = new HashSet<>(followingIds);
+        excludeIds.addAll(blockedIds);
+        excludeIds.add(meId);
+        if (excludeIds.isEmpty()) {
+            excludeIds.add(0L);
+        }
+
+        log.info(">>>> [디버깅 0] 팔로우 {}명, 차단 {}명 등 총 {}명 추천에서 제외",
+                followingIds.size(), blockedIds.size(), excludeIds.size());
+
+        List<User> allCandidates = userRepository.findFullProfiledRecommendationCandidates(excludeIds);
+        log.info(">>>> [디버깅 1] 최종 필터링 후 조회된 후보 수: {}", allCandidates.size());
+
+        if (allCandidates.isEmpty()) {
+            return List.of();
+        }
+
         int meAge = safeAge(me.getBirthdate());
         Set<String> meLangs = csvToSet(me.getLanguage());
 
-        Page<User> page = userRepository.findPageNullMemberAndMember(
-                meId, PageRequest.of(0, 1000, Sort.by(Sort.Direction.DESC, "updatedAt"))
-        );
+        List<Scored<User>> scored = allCandidates.stream()
+                .map(candidate -> new Scored<>(candidate, score(me, candidate, meAge, meLangs)))
+                .collect(Collectors.toList());
 
-        log.info(">>>> [디버깅 1] DB에서 조회된 초기 후보 수: {}", page.getContent().size());
-
-        if (!page.hasContent()) {
-            return List.of();
-        }
-        List<User> filteredUsers = page.getContent().stream()
-                .filter(candidate -> !isBlocked(me, candidate))
-                .toList();
-
-        log.info(">>>> [디버깅 1.5] 차단 필터링 후 남은 후보 수: {}", filteredUsers.size());
-        log.info(">>>> 리미트 수 : {}",limit);
-
-        if (filteredUsers.isEmpty()) {
-            log.info(">>>> [디버깅 1.6] 차단 필터링 후 남은 후보가 없습니다.");
-            return List.of();
-        }
-
-        List<Scored<User>> scored = new ArrayList<>();
-        for (User cand : filteredUsers) {
-            double s = score(me, cand, meAge, meLangs);
-            scored.add(new Scored<>(cand, s));
-        }
-
-        log.info(">>>> [디버깅 2] 점수 계산 후 후보 수: {}", scored.size());
-
-        scored.sort((a, b) -> Double.compare(b.score, a.score));
-
-        if (scored.size() <= limit) {
-            log.info(">>>> [디버깅 3] 후보 수가 limit({}) 이하이므로 모두 반환합니다.", limit);
-            return scored.stream()
-                    .map(s -> toDto(s.getItem()))
-                    .toList();
-        }
-
-        log.info(">>>> [디버깅 4] 후보 수가 충분하여 확률적 재랭킹을 시작합니다.");
-        int poolK = Math.min(Math.max(limit * POOL_MULTIPLIER, MIN_POOL), scored.size());
-        int finalLimit = Math.min(limit, poolK);
-        List<User> chosen = pickGumbelTopK(scored.subList(0, poolK), finalLimit, TEMPERATURE);
+        log.info(">>>> [디버깅 2] 전체 {}명 후보 대상 확률적 랭킹 시작", scored.size());
+        List<User> chosen = pickGumbelTopK(scored, limit, TEMPERATURE);
 
         return chosen.stream().map(this::toDto).toList();
     }
@@ -119,18 +101,33 @@ public class ContentBasedRecommender {
         return draws.stream().limit(Math.max(1, limit)).map(d -> d.u).toList();
     }
 
+    /** [수정] 활동 점수를 포함하고, 'me'의 불완전 프로필을 처리하는 최종 점수 계산 메서드 */
     private double score(User me, User other, int meAge, Set<String> meLangs) {
-        double purposeScore = eq(me.getPurpose(), other.getPurpose()) ? 1.0 : 0.0;
-        double countryScore = eq(me.getCountry(), other.getCountry()) ? 1.0 : 0.0;
+        double purposeScore = (me.getPurpose() == null || me.getPurpose().isBlank())
+                ? 0.5 : (eq(me.getPurpose(), other.getPurpose()) ? 1.0 : 0.0);
+        double countryScore = (me.getCountry() == null || me.getCountry().isBlank())
+                ? 0.5 : (eq(me.getCountry(), other.getCountry()) ? 1.0 : 0.0);
+
         double ageScore = ageSim(meAge, safeAge(other.getBirthdate()), 9.0);
         double langScore = jaccard(meLangs, csvToSet(other.getLanguage()));
-
+        double activityScore = calculateActivityScore(other, ACTIVITY_SCORE_HALF_LIFE_DAYS);
         return W_PURPOSE * purposeScore
                 + W_COUNTRY * countryScore
                 + W_AGE * ageScore
-                + W_LANG * langScore;
+                + W_LANG * langScore
+                + W_ACTIVITY * activityScore;
     }
 
+    /** [추가] 사용자의 마지막 활동 시간(lastSeenAt)을 바탕으로 0.0 ~ 1.0 사이의 활동 점수를 계산 */
+    private double calculateActivityScore(User user, double halfLifeDays) {
+        if (user.getLastSeenAt() == null) {
+            return 0.0;
+        }
+        long hoursSinceUpdate = ChronoUnit.HOURS.between(user.getLastSeenAt(), Instant.now());
+        double daysSinceUpdate = hoursSinceUpdate / 24.0;
+        double decayRate = Math.log(2) / halfLifeDays;
+        return Math.exp(-decayRate * daysSinceUpdate);
+    }
     private double ageSim(int a, int b, double sigma) {
         if (a <= 0 || b <= 0) return 0.5;
         return Math.exp(-Math.abs(a - b) / sigma);
@@ -149,12 +146,14 @@ public class ContentBasedRecommender {
     }
 
     private double jaccard(Set<String> A, Set<String> B) {
-        if (A.isEmpty() && B.isEmpty()) return 0.0;
-        Set<String> inter = new HashSet<>(A);
-        inter.retainAll(B);
-        Set<String> uni = new HashSet<>(A);
-        uni.addAll(B);
-        return uni.isEmpty() ? 0.0 : (double) inter.size() / (double) uni.size();
+        if (!A.isEmpty() || !B.isEmpty()) {
+            Set<String> inter = new HashSet<>(A);
+            inter.retainAll(B);
+            Set<String> uni = new HashSet<>(A);
+            uni.addAll(B);
+            return uni.isEmpty() ? 0.0 : (double) inter.size() / (double) uni.size();
+        }
+        return 0.5;
     }
 
     private int safeAge(String birth) {
@@ -179,7 +178,6 @@ public class ContentBasedRecommender {
         String imageKey = imageRepository.findFirstByImageTypeAndRelatedIdOrderByOrderIndexAsc(ImageType.USER, u.getId())
                 .map(image -> image.getUrl())
                 .orElse(null);
-        log.info("imageKey :{}",imageKey);
 
         return UserUpdateDTO.builder()
                 .userId(u.getId())
@@ -194,9 +192,5 @@ public class ContentBasedRecommender {
                 .hobby(csvToSet(u.getHobby()).stream().toList())
                 .imageKey(imageKey)
                 .build();
-    }
-    private boolean isBlocked(User me, User candidate) {
-        return blockRepository.existsBlock(me.getId(), candidate.getId()) ||
-                blockRepository.existsBlock(candidate.getId(), me.getId());
     }
 }

--- a/src/main/java/core/domain/user/service/UserActivityService.java
+++ b/src/main/java/core/domain/user/service/UserActivityService.java
@@ -1,0 +1,28 @@
+package core.domain.user.service;
+
+import core.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+@Service
+@RequiredArgsConstructor
+public class UserActivityService {
+
+    private final UserRepository userRepository;
+
+    @Async
+    @Transactional
+    public void updateLastSeenAt(String email) {
+        userRepository.findByEmail(email).ifPresent(user -> {
+            if (user.getLastSeenAt() == null ||
+                    ChronoUnit.MINUTES.between(user.getLastSeenAt(), Instant.now()) > 5) {
+                user.updateLastSeenAt();
+            }
+        });
+    }
+}

--- a/src/main/java/core/global/config/StompChannelInterceptor.java
+++ b/src/main/java/core/global/config/StompChannelInterceptor.java
@@ -1,5 +1,6 @@
 package core.global.config;
 
+import core.domain.user.service.UserActivityService;
 import core.global.enums.ErrorCode;
 import core.global.service.RedisService;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +26,7 @@ public class StompChannelInterceptor implements ChannelInterceptor {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final RedisService redisService;
-
+    private final UserActivityService userActivityService;
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
@@ -63,6 +64,8 @@ public class StompChannelInterceptor implements ChannelInterceptor {
                 Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
                 if (sessionAttributes != null) {
                     sessionAttributes.put("userAuth", auth);
+                    String userEmail = auth.getName();
+                    userActivityService.updateLastSeenAt(userEmail);
                 }
 
                 // accessor.setUser(auth); // 기존 방식도 함께 사용 가능 (다른 곳에서 필요할 수 있음)

--- a/src/main/java/core/global/config/UserActivityInterceptor.java
+++ b/src/main/java/core/global/config/UserActivityInterceptor.java
@@ -1,0 +1,26 @@
+package core.global.config;
+
+import core.domain.user.service.UserActivityService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@RequiredArgsConstructor
+public class UserActivityInterceptor implements HandlerInterceptor {
+
+    private final UserActivityService userActivityService;
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated() && !"anonymousUser".equals(authentication.getPrincipal())) {
+            String userEmail = authentication.getName();
+            userActivityService.updateLastSeenAt(userEmail);
+        }
+    }
+}

--- a/src/main/java/core/global/config/WebConfig.java
+++ b/src/main/java/core/global/config/WebConfig.java
@@ -1,0 +1,19 @@
+package core.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final UserActivityInterceptor userActivityInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(userActivityInterceptor)
+                .addPathPatterns("/api/**");
+    }
+}

--- a/src/main/resources/db/migration/V7__Add_last_seen_at_to_users.sql
+++ b/src/main/resources/db/migration/V7__Add_last_seen_at_to_users.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN last_seen_at TIMESTAMP;


### PR DESCRIPTION
# 📄 PR 변경사항
- 기존 친구 추천 로직의 고질적인 문제였던 추천 고착화(Stagnation) 및 후보군 필터링 오류를 해결했습니다.
- 사용자의 실제 활동을 정확히 추적하기 위해 lastSeenAt 기반의 활동 점수 시스템을 도입했습니다.
- 추천 알고리즘을 전면 리팩토링하여 추천의 다양성과 정확성을 대폭 향상

# 🖌️ 구체적인 구현 내용
기존 추천 로직은 사용자가 늘어날수록 추천 목록이 고착화되고 새로운 사용자를 발견하기 어려운 구조적인 결함을 가지고 있었습니다. 구체적인 문제 상황은 다음과 같습니다.

가령 총 유저가 260명이고, 내가 90명을 팔로우했을 때 남은 150명이 추천 목록에 보여야 하지만 실제로는 보이지 않는 현상이 있었습니다.

1. 함정 1: 팔로우한 사용자가 제외되지 않았습니다.
가장 큰 문제점으로, 기존 userRepository.findPageNullMemberAndMember(...) 쿼리는 이미 팔로우한 90명의 사용자를 추천 후보에서 제외하지 않았습니다. 따라서 추천 후보군에는 내가 이미 아는 사람들이 대거 포함되어 있었습니다.

2. 함정 2: 여러 단계의 필터링으로 후보군이 소멸되었습니다.
DB에서 모든 사용자를 조회했더라도, 최종 추천까지 이어지는 과정에서 대부분의 후보가 탈락했습니다.

1단계: DB 조회: PageRequest를 통해 updatedAt 순으로 260명의 사용자가 정렬됩니다. 이 목록에는 팔로우한 90명과 아직 보지 못한 150명이 모두 섞여 있습니다.

2단계: 점수 계산: 260명 전원에 대해 유사도 점수를 계산합니다. 이미 팔로우한 90명은 나와 유사도가 높을 확률이 크므로, 이 단계에서 매우 높은 점수를 받게 됩니다.

3단계: 점수 순 정렬: 계산된 점수 순으로 260명이 다시 정렬됩니다. 결과적으로, 점수가 높은 90명(이미 팔로우한)이 목록의 최상위권을 대부분 차지하게 됩니다.

4단계: 상위 100명 선발 (결정적 문제): scored.subList(0, 100) 코드를 통해 점수 상위 100명만 최종 후보로 간택됩니다. 101등 이하의 나머지 사용자들은 이 단계에서 그냥 버려져 추천될 확률이 0%가 됩니다.

**결론적으로, 사용자는 (내가 이미 팔로우한 유저 + 일부 새로운 유저)로 구성된 상위 100명의 고정된 풀 안에서만 계속 추천을 받게 되어, 아직 보지 못한 150명 중 대다수를 만날 기회 자체가 없었습니다.**

**1. 정확한 사용자 활동 추적 시스템 구축**
lastSeenAt 필드 도입: updatedAt 대신 실제 사용자 활동(API 호출, 채팅 등)을 반영하는 lastSeenAt 필드를 User 엔티티에 추가하고, Flyway 마이그레이션을 진행했습니다.
UserActivityService 추가: @Async를 통해 API 성능에 영향을 주지 않고 백그라운드에서 lastSeenAt을 갱신하는 서비스를 구현했습니다.
UserActivityInterceptor 추가: 일반적인 HTTP API(@GetMapping 등) 요청을 감지하여 활동 시간을 기록합니다.
StompChannelInterceptor 수정: 웹소켓을 통한 채팅 메시지(SEND, SUBSCRIBE) 활동을 감지하여 기록합니다.

**2. 후보군 선정 로직 개선**
updatedAt 정렬 완전 제거: 추천 고착화의 주범이었던 시간순 정렬을 제거했습니다.
명확한 필터링 적용:
FollowRepository를 통해 PENDING, ACCEPTED 상태의 사용자를 추천에서 명확히 제외합니다.
BlockRepository를 통해 차단 관계의 사용자를 양방향으로 제외합니다.
UserRepository에 JPQL 쿼리를 추가하여, 프로필이 완벽하게 설정된 사용자만 추천 후보로 선정합니다.

3. 추천 점수(Score) 계산 방식 고도화
5-Factor 모델: 기존 4가지 유사도 점수(목적, 국가, 나이, 언어)에 활동 점수를 추가하여 총 5가지 요소를 종합 평가합니다.
활동 점수(Activity Score) 계산: lastSeenAt을 기반으로 시간 감쇠(Time Decay) 함수를 적용하여, 최근 활동 사용자에게 더 높은 점수를 부여합니다.
불완전 프로필 처리: 추천을 요청하는 사용자(me)의 프로필이 불완전하더라도, 중립 점수를 부여하여 추천 로직이 안정적으로 동작하도록 개선했습니다.

**4. 랜덤성 및 다양성 강화**
Gumbel-Top-K 알고리즘 전면 적용: 점수 상위 일부가 아닌, 필터링된 전체 후보군을 대상으로 랜덤 랭킹을 적용하여 추천의 다양성을 대폭 향상시켰습니다.
TEMPERATURE 값 상향 (0.1 -> 0.7): 랜덤성의 영향력을 높여, 사용자가 새로고침 시 새로운 인물을 발견할 확률을 크게 높였습니다.

# ✨개선 사항 및 참고 사항
추천 점수에 사용되는 가중치(W_...), TEMPERATURE, 활동 점수 반감기(ACTIVITY_SCORE_HALF_LIFE_DAYS)는 ContentBasedRecommender 클래스 상단에서 상수로 관리되므로, 향후 운영 데이터에 따라 쉽게 튜닝할 수 있습니다.

팔로우 로직(FollowService)에서 프로필이 미완성인 사용자의 팔로우 요청을 차단하는 비즈니스 로직은 별도 PR로 처리되거나 이어서 구현될 예정입니다.


# 💯 테스트
Postman을 통한 수동 테스트:
특정 사용자로 로그인 후 친구 추천 API를 반복적으로 호출하여 매번 다른 결과가 나오는지, 
추천 목록의 다양성이 확보되었는지 확인했습니다.
A가 B를 팔로우한 후, A의 추천 목록에 B가 더 이상 나타나지 않는 것을 확인했습니다.
프로필이 미완성된 사용자는 추천 목록에 나타나지 않는 것을 확인했습니다.

최근 활동한 사용자가 추천 목록에 더 자주 등장하는 경향을 확인했습니다.
# 확인
- [x] 주석 및 print를 제거하셨나요?
- [x] javaDoc을 작성하셨나요?
- [x] merge할 브랜치와 로컬에서 merge 하셨나요?
- [x] 더 수정할 작업은 없는지 확인하셨나요?
