### PR TITLE
Feat/alram random

### DIFF
--- a/src/main/java/core/domain/chat/controller/ChatController.java
+++ b/src/main/java/core/domain/chat/controller/ChatController.java
@@ -399,4 +399,22 @@ public class ChatController {
         PresignedUrlResponse response = chatService.generateChatPresignedUrl(chatroomId, request.fileName());
         return ResponseEntity.ok(ApiResponse.success(response));
     }
+    @Operation(summary = "채팅방 알림 설정 변경", description = "특정 채팅방의 알림을 켜거나 끕니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "알림 설정 변경 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "채팅방 또는 해당 채팅방의 참여자가 아닐 경우")
+    })
+    @PostMapping("/rooms/{roomId}/notifications")
+    public ResponseEntity<ApiResponse<Void>> toggleChatRoomNotifications(
+            @Parameter(description = "설정을 변경할 채팅방의 ID") @PathVariable Long roomId,
+            @Valid @RequestBody ToggleNotificationsRequest request
+    ) {
+        CustomUserDetails principal = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        Long userId = principal.getUserId();
+
+        chatService.toggleChatRoomNotifications(roomId, userId, request.enabled());
+
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
 }

--- a/src/main/java/core/domain/chat/dto/ToggleNotificationsRequest.java
+++ b/src/main/java/core/domain/chat/dto/ToggleNotificationsRequest.java
@@ -1,0 +1,12 @@
+package core.domain.chat.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "채팅방 알림 설정 변경 요청 DTO")
+public record ToggleNotificationsRequest(
+        @NotNull(message = "enabled 필드는 필수입니다.")
+        @Schema(description = "알림 활성화 여부", example = "true")
+        Boolean enabled
+) {
+}

--- a/src/main/java/core/domain/chat/entity/ChatParticipant.java
+++ b/src/main/java/core/domain/chat/entity/ChatParticipant.java
@@ -77,5 +77,13 @@ public class ChatParticipant {
     public void setLastReadMessageId(Long messageId) {
         this.lastReadMessageId = messageId;
     }
+
+    /**
+     * 이 참여자의 채팅방 알림 설정을 변경합니다.
+     * @param enabled 알림을 활성화할지 여부 (true: 켬, false: 끔)
+     */
+    public void setNotificationsEnabled(boolean enabled) {
+        this.notificationsEnabled = enabled;
+    }
 }
 

--- a/src/main/java/core/domain/chat/service/ChatService.java
+++ b/src/main/java/core/domain/chat/service/ChatService.java
@@ -1297,4 +1297,24 @@ public class ChatService {
 
         return new PresignedUrlResponse(presignedUrl, fileKey);
     }
+
+    /**
+     * 특정 채팅방에 대한 사용자의 알림 설정을 변경합니다.
+     *
+     * @param roomId  설정을 변경할 채팅방 ID
+     * @param userId  설정을 변경하는 사용자 ID
+     * @param enabled 알림을 활성화할지 여부
+     */
+    @Transactional
+    public void toggleChatRoomNotifications(Long roomId, Long userId, boolean enabled) {
+
+        Optional<ChatParticipant> participantOptional = chatParticipantRepository.findByChatRoomIdAndUserId(roomId, userId);
+        if (participantOptional.isEmpty()) {
+            throw new BusinessException(ErrorCode.CHAT_PARTICIPANT_NOT_FOUND);
+        }
+
+        ChatParticipant participant = participantOptional.get();
+        participant.setNotificationsEnabled(enabled);
+
+    }
 }

--- a/src/main/java/core/domain/comment/service/impl/CommentServiceImpl.java
+++ b/src/main/java/core/domain/comment/service/impl/CommentServiceImpl.java
@@ -198,8 +198,7 @@ public class CommentServiceImpl implements CommentService {
                     ? Comment.createRootComment(post, user, request.comment(), request.anonymous())
                     : Comment.createReplyComment(post, user, request.comment(), request.anonymous(), parent);
 
-            commentRepository.save(toSave);
-
+            Comment savedComment = commentRepository.save(toSave);
             // --- 알림 이벤트 구분 발행 ---
             if (parent == null) {
                 // 게시글에 댓글 작성 시 → 게시글 작성자에게 알림
@@ -209,6 +208,7 @@ public class CommentServiceImpl implements CommentService {
                             user.getId(),
                             NotificationType.post,
                             post.getId(),
+                            savedComment.getId(), // ✅ 2. 저장된 댓글의 ID를 이벤트에 추가
                             request.comment()
                     );
                     eventPublisher.publishEvent(event);
@@ -221,6 +221,7 @@ public class CommentServiceImpl implements CommentService {
                             user.getId(),
                             NotificationType.comment,
                             post.getId(),
+                            savedComment.getId(), // ✅ 2. 저장된 답글의 ID를 이벤트에 추가
                             request.comment()
                     );
                     eventPublisher.publishEvent(event);

--- a/src/main/java/core/domain/notification/controller/UserNotificationController.java
+++ b/src/main/java/core/domain/notification/controller/UserNotificationController.java
@@ -101,10 +101,11 @@ public class UserNotificationController {
                                                       "message": "success",
                                                       "data": [
                                                     { "notificationType": "post", "enabled": true },
-                                                { "notificationType": "comment", "enabled": true },
-                                                { "notificationType": "chat", "enabled": false },
-                                                { "notificationType": "follow", "enabled": true },
-                                                { "notificationType": "receive", "enabled": false }
+                                                    { "notificationType": "comment", "enabled": true },
+                                                    { "notificationType": "chat", "enabled": false },
+                                                    { "notificationType": "follow", "enabled": true },
+                                                    { "notificationType": "receive", "enabled": false }
+                                                    { "notificationType": "followuserpost", "enabled": true }
                                                       ],
                                                       "timestamp": "2025-10-03T12:00:00"
                                                     }
@@ -172,6 +173,7 @@ public class UserNotificationController {
                                                 { "notificationType": "chat", "enabled": true },
                                                 { "notificationType": "follow", "enabled": true },
                                                 { "notificationType": "receive", "enabled": false }
+                                                { "notificationType": "followuserpost", "enabled": true }
                                               ]
                                             }
                                             """
@@ -196,6 +198,7 @@ public class UserNotificationController {
                                                           { "type": "chat", "enabled": true },
                                                           { "type": "follow", "enabled": true },
                                                           { "type": "receive", "enabled": false }
+                                                          { "notificationType": "followuserpost", "enabled": true }
                                                         ]
                                                       }
                                                       "timestamp": "2025-10-03T12:00:00"
@@ -265,6 +268,7 @@ public class UserNotificationController {
                                                 { "notificationType": "chat", "enabled": true },
                                                 { "notificationType": "follow", "enabled": true },
                                                 { "notificationType": "receive", "enabled": true }
+                                                { "notificationType": "followuserpost", "enabled": true }
                                               ]
                                             }
                                             """

--- a/src/main/java/core/domain/notification/controller/UserNotificationController.java
+++ b/src/main/java/core/domain/notification/controller/UserNotificationController.java
@@ -342,4 +342,17 @@ public class UserNotificationController {
 
         return ResponseEntity.ok(ApiResponse.success(null));
     }
+    @Operation(summary = "알림 읽음 처리", description = "특정 알림을 '읽음' 상태로 변경합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "읽음 처리 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "알림을 찾을 수 없거나, 본인의 알림이 아닐 경우")
+    })
+    @PostMapping("/{notificationId}/read")
+    public ResponseEntity<ApiResponse<Void>> markNotificationAsRead(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long notificationId
+    ) {
+        userNotificationService.markNotificationAsRead(userDetails.getUserId(), notificationId);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
 }

--- a/src/main/java/core/domain/notification/controller/UserNotificationController.java
+++ b/src/main/java/core/domain/notification/controller/UserNotificationController.java
@@ -333,7 +333,4 @@ public class UserNotificationController {
 
         return ResponseEntity.ok(ApiResponse.success(null));
     }
-
-
-
 }

--- a/src/main/java/core/domain/notification/controller/UserNotificationController.java
+++ b/src/main/java/core/domain/notification/controller/UserNotificationController.java
@@ -104,8 +104,9 @@ public class UserNotificationController {
                                                     { "notificationType": "comment", "enabled": true },
                                                     { "notificationType": "chat", "enabled": false },
                                                     { "notificationType": "follow", "enabled": true },
-                                                    { "notificationType": "receive", "enabled": false }
-                                                    { "notificationType": "followuserpost", "enabled": true }
+                                                    { "notificationType": "receive", "enabled": false },
+                                                    { "notificationType": "followuserpost", "enabled": true },
+                                                    { "notificationType": "newuser", "enabled": true },
                                                       ],
                                                       "timestamp": "2025-10-03T12:00:00"
                                                     }
@@ -172,8 +173,9 @@ public class UserNotificationController {
                                                 { "notificationType": "comment", "enabled": false },
                                                 { "notificationType": "chat", "enabled": true },
                                                 { "notificationType": "follow", "enabled": true },
-                                                { "notificationType": "receive", "enabled": false }
-                                                { "notificationType": "followuserpost", "enabled": true }
+                                                { "notificationType": "receive", "enabled": false },
+                                                { "notificationType": "followuserpost", "enabled": true },
+                                                { "notificationType": "newuser", "enabled": true }
                                               ]
                                             }
                                             """
@@ -198,7 +200,9 @@ public class UserNotificationController {
                                                           { "type": "chat", "enabled": true },
                                                           { "type": "follow", "enabled": true },
                                                           { "type": "receive", "enabled": false }
-                                                          { "notificationType": "followuserpost", "enabled": true }
+                                                          { "notificationType": "followuserpost", "enabled": true },
+                                                          { "notificationType": "newuser", "enabled": true }
+                                                 
                                                         ]
                                                       }
                                                       "timestamp": "2025-10-03T12:00:00"
@@ -267,8 +271,9 @@ public class UserNotificationController {
                                                 { "notificationType": "comment", "enabled": true },
                                                 { "notificationType": "chat", "enabled": true },
                                                 { "notificationType": "follow", "enabled": true },
-                                                { "notificationType": "receive", "enabled": true }
-                                                { "notificationType": "followuserpost", "enabled": true }
+                                                { "notificationType": "receive", "enabled": true },
+                                                { "notificationType": "followuserpost", "enabled": true },
+                                                { "notificationType": "newuser", "enabled": true }
                                               ]
                                             }
                                             """

--- a/src/main/java/core/domain/notification/dto/NewUserJoinedEvent.java
+++ b/src/main/java/core/domain/notification/dto/NewUserJoinedEvent.java
@@ -1,0 +1,11 @@
+package core.domain.notification.dto;
+
+
+/**
+ * 신규 유저 가입 사실을 알리는 이벤트 DTO
+ * @param newUserId 새로 가입한 유저의 ID
+ */
+public record NewUserJoinedEvent(
+        Long newUserId
+) {
+}

--- a/src/main/java/core/domain/notification/dto/NotificationEvent.java
+++ b/src/main/java/core/domain/notification/dto/NotificationEvent.java
@@ -1,12 +1,27 @@
 package core.domain.notification.dto;
 
-import core.domain.user.entity.User;
+
 import core.global.enums.NotificationType;
 
+/**
+ * 알림 이벤트 DTO
+ *
+ * @param recipientId      알림 수신자 ID
+ * @param actorId          알림 유발자 ID
+ * @param notificationType 알림 유형
+ * @param referenceId      관련 콘텐츠의 주요 ID (예: postId, chatRoomId)
+ * @param commentId        관련 댓글 ID (댓글/답글 알림 전용, 그 외에는 null)
+ * @param contentSnippet   콘텐츠 일부 (예: 채팅 메시지 내용)
+ */
 public record NotificationEvent(
         Long recipientId,
         Long actorId,
         NotificationType notificationType,
         Long referenceId,
+        Long commentId,
         String contentSnippet
-) {}
+) {
+    public NotificationEvent(Long recipientId, Long actorId, NotificationType notificationType, Long referenceId, String contentSnippet) {
+        this(recipientId, actorId, notificationType, referenceId, null, contentSnippet);
+    }
+}

--- a/src/main/java/core/domain/notification/service/NotificationEventListener.java
+++ b/src/main/java/core/domain/notification/service/NotificationEventListener.java
@@ -76,7 +76,6 @@ public class NotificationEventListener {
 
         List<User> allUsers = userRepository.findAll();
         log.warn("[성능 경고] {}명의 모든 사용자를 메모리에 로드했습니다. 사용자 수가 많을 경우 OutOfMemoryError가 발생할 수 있습니다.", allUsers.size());
-        // =======================================
 
         for (User recipient : allUsers) {
             if (recipient.getId().equals(newUserActor.getId())) {

--- a/src/main/java/core/domain/notification/service/NotificationEventListener.java
+++ b/src/main/java/core/domain/notification/service/NotificationEventListener.java
@@ -1,5 +1,6 @@
 package core.domain.notification.service;
 
+import core.domain.notification.dto.NewUserJoinedEvent;
 import core.domain.notification.dto.NotificationEvent;
 import core.domain.user.entity.User;
 import core.domain.user.repository.UserRepository;
@@ -9,6 +10,8 @@ import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional; // ✅ @Transactional 임포트
+
+import java.util.List;
 
 @Slf4j
 @Component
@@ -46,5 +49,47 @@ public class NotificationEventListener {
         } catch (Exception e) {
             log.error("알림 이벤트 처리 중 오류 발생: {}", event, e);
         }
+    }
+
+    /**
+     * ✅ [비효율적인 버전]
+     * 신규 유저 가입 이벤트를 받아 전체 사용자에게 알림을 발송합니다.
+     * 추후 최적화 필요
+     */
+    @Async("dispatchExecutor")
+    @EventListener
+    @Transactional
+    public void handleNewUserBroadcastInefficiently(NewUserJoinedEvent event) {
+        log.info("[비효율적 방식] 신규 유저 가입 이벤트 수신. 전체 알림 발송을 시작합니다. 신규 유저 ID: {}", event.newUserId());
+
+        User newUserActor = userRepository.findById(event.newUserId()).orElse(null);
+        if (newUserActor == null) {
+            log.warn("신규 유저 정보를 찾을 수 없어 전체 알림을 중단합니다. ID: {}", event.newUserId());
+            return;
+        }
+
+        NotificationEvent tempEvent = new NotificationEvent(
+                null, newUserActor.getId(),
+                core.global.enums.NotificationType.newuser,
+                newUserActor.getId(), null, null);
+        String message = notificationMessageGenerator.generateMessage(newUserActor, tempEvent);
+
+        List<User> allUsers = userRepository.findAll();
+        log.warn("[성능 경고] {}명의 모든 사용자를 메모리에 로드했습니다. 사용자 수가 많을 경우 OutOfMemoryError가 발생할 수 있습니다.", allUsers.size());
+        // =======================================
+
+        for (User recipient : allUsers) {
+            if (recipient.getId().equals(newUserActor.getId())) {
+                continue;
+            }
+
+            try {
+                notificationService.createAndSaveNotification(recipient, tempEvent, message);
+                pushNotificationService.sendPushNotification(recipient, tempEvent, message);
+            } catch (Exception e) {
+                log.error("사용자 ID {}에게 신규 유저 알림 발송 중 오류 발생", recipient.getId(), e);
+            }
+        }
+        log.info("[비효율적 방식] 전체 알림 발송 루프 완료. 총 {}명 처리.", allUsers.size());
     }
 }

--- a/src/main/java/core/domain/notification/service/NotificationMessageGenerator.java
+++ b/src/main/java/core/domain/notification/service/NotificationMessageGenerator.java
@@ -35,6 +35,7 @@ public class NotificationMessageGenerator {
             case follow -> actorName + "님이 회원님의 팔로우 요청을 수락했습니다.";
             case receive -> actorName + "님이 회원님을 팔로우하기 시작했습니다.";
             case newuser -> actorName + "님이 새로 가입했습니다! 환영해주세요.";
+            case followuserpost -> actorName + "님이 새로운 게시글을 작성했습니다.";
             default -> "새로운 알림이 도착했습니다.";
         };
     }

--- a/src/main/java/core/domain/notification/service/NotificationMessageGenerator.java
+++ b/src/main/java/core/domain/notification/service/NotificationMessageGenerator.java
@@ -34,6 +34,7 @@ public class NotificationMessageGenerator {
 
             case follow -> actorName + "님이 회원님의 팔로우 요청을 수락했습니다.";
             case receive -> actorName + "님이 회원님을 팔로우하기 시작했습니다.";
+            case newuser -> actorName + "님이 새로 가입했습니다! 환영해주세요.";
             default -> "새로운 알림이 도착했습니다.";
         };
     }

--- a/src/main/java/core/domain/notification/service/PushNotificationService.java
+++ b/src/main/java/core/domain/notification/service/PushNotificationService.java
@@ -109,6 +109,11 @@ public class PushNotificationService {
                             .putData("url", "/newuser")
                             .putData("userId", String.valueOf(event.referenceId()));
                     break;
+                case followuserpost:
+                    messageBuilder
+                            .putData("url", "/community")
+                            .putData("postId", String.valueOf(event.referenceId()));
+                    break;
                 default:
                     break;
             }

--- a/src/main/java/core/domain/notification/service/PushNotificationService.java
+++ b/src/main/java/core/domain/notification/service/PushNotificationService.java
@@ -35,39 +35,33 @@ public class PushNotificationService {
     /**
      * 사용자에게 푸시 알림을 발송합니다. (람다 제거 버전)
      * 발송 전 3단계 동의 여부를 모두 확인합니다.
+     * 클라이언트 이동을 위한 data 페이로드를 포함합니다.
      * @param event 알림 이벤트 데이터
      * @param message 사용자에게 보여줄 최종 메시지
      */
-    public void sendPushNotification(User recipient,NotificationEvent event, String message) {
+    public void sendPushNotification(User recipient, NotificationEvent event, String message) {
 
+        // 1단계: 마스터 푸시 알림 동의 여부 확인
         if (!recipient.isAgreedToPushNotification()) {
             log.info("사용자 ID {}: 마스터 스위치 OFF. 푸시 알림을 발송하지 않습니다.", recipient.getId());
             return;
         }
 
+        // 2단계: 카테고리별 알림 설정 확인
         boolean isCategoryEnabled;
         Optional<UserNotificationSetting> categorySettingOpt = userNotificationSettingRepository.findByUserAndNotificationType(recipient, event.notificationType());
-
-        if (categorySettingOpt.isPresent()) {
-            isCategoryEnabled = categorySettingOpt.get().isEnabled();
-        } else {
-            isCategoryEnabled = true;
-        }
+        isCategoryEnabled = categorySettingOpt.map(UserNotificationSetting::isEnabled).orElse(true);
 
         if (!isCategoryEnabled) {
             log.info("사용자 ID {}: '{}' 카테고리 스위치 OFF. 푸시 알림을 발송하지 않습니다.", recipient.getId(), event.notificationType());
             return;
         }
 
+        // 3단계: 채팅방별 알림 설정 확인 (채팅 알림인 경우)
         if (event.notificationType() == NotificationType.chat) {
             boolean isRoomNotificationsEnabled;
             Optional<ChatParticipant> participantOpt = chatParticipantRepository.findByChatRoomIdAndUserId(event.referenceId(), recipient.getId());
-
-            if (participantOpt.isPresent()) {
-                isRoomNotificationsEnabled = participantOpt.get().isNotificationsEnabled();
-            } else {
-                isRoomNotificationsEnabled = false;
-            }
+            isRoomNotificationsEnabled = participantOpt.map(ChatParticipant::isNotificationsEnabled).orElse(false);
 
             if (!isRoomNotificationsEnabled) {
                 log.info("사용자 ID {}: 채팅방 ID {} 음소거 상태. 푸시 알림을 발송하지 않습니다.", recipient.getId(), event.referenceId());
@@ -76,17 +70,51 @@ public class PushNotificationService {
         }
 
         List<UserDeviceToken> deviceTokens = userDeviceTokenRepository.findAllByUser(recipient);
-
         for (UserDeviceToken userDeviceToken : deviceTokens) {
-            Message fcmMessage = Message.builder()
+            Message.Builder messageBuilder = Message.builder()
                     .setToken(userDeviceToken.getDeviceToken())
                     .setNotification(com.google.firebase.messaging.Notification.builder()
                             .setTitle("Foreigner")
                             .setBody(message)
                             .build())
-                    .putData("notificationType", event.notificationType().name())
-                    .putData("referenceId", String.valueOf(event.referenceId()))
-                    .build();
+                    .putData("notificationType", event.notificationType().name());
+
+            switch (event.notificationType()) {
+                case post, comment:
+                    messageBuilder
+                            .putData("url", "/community")
+                            .putData("postId", String.valueOf(event.referenceId()));
+                    if (event.commentId() != null) {
+                        messageBuilder.putData("commentId", String.valueOf(event.commentId()));
+                    }
+                    break;
+                case follow:
+                    messageBuilder
+                            .putData("url", "/mypage/friends")
+                            .putData("friendId", String.valueOf(event.actorId()));
+                    break;
+                case receive:
+                    messageBuilder
+                            .putData("url", "/mypage/follows")
+                            .putData("followerId", String.valueOf(event.actorId()));
+                    break;
+                case chat:
+                    messageBuilder
+                            .putData("url", "/chatscreen/ChattingRoomScreen")
+                            .putData("roomId", String.valueOf(event.referenceId()))
+                            .putData("myId", String.valueOf(recipient.getId()));
+                    break;
+                case newuser:
+                    messageBuilder
+                            .putData("url", "/newuser")
+                            .putData("userId", String.valueOf(event.referenceId()));
+                    //TODO 유저 상세 보기 페이지로 넘겨야함, 아직 클라이언트에서 구현안됨  수정 예정
+                default:
+                    break;
+            }
+
+            Message fcmMessage = messageBuilder.build();
+
             try {
                 firebaseMessaging.send(fcmMessage);
                 log.info("사용자 ID {} 에게 푸시 알림을 성공적으로 발송했습니다. (기기 토큰: ...{})", recipient.getId(), userDeviceToken.getDeviceToken().substring(userDeviceToken.getDeviceToken().length() - 5));

--- a/src/main/java/core/domain/notification/service/PushNotificationService.java
+++ b/src/main/java/core/domain/notification/service/PushNotificationService.java
@@ -108,7 +108,7 @@ public class PushNotificationService {
                     messageBuilder
                             .putData("url", "/newuser")
                             .putData("userId", String.valueOf(event.referenceId()));
-                    //TODO 유저 상세 보기 페이지로 넘겨야함, 아직 클라이언트에서 구현안됨  수정 예정
+                    break;
                 default:
                     break;
             }

--- a/src/main/java/core/domain/notification/service/PushNotificationService.java
+++ b/src/main/java/core/domain/notification/service/PushNotificationService.java
@@ -41,23 +41,21 @@ public class PushNotificationService {
      */
     public void sendPushNotification(User recipient, NotificationEvent event, String message) {
 
-        // 1단계: 마스터 푸시 알림 동의 여부 확인
         if (!recipient.isAgreedToPushNotification()) {
             log.info("사용자 ID {}: 마스터 스위치 OFF. 푸시 알림을 발송하지 않습니다.", recipient.getId());
             return;
         }
 
-        // 2단계: 카테고리별 알림 설정 확인
-        boolean isCategoryEnabled;
-        Optional<UserNotificationSetting> categorySettingOpt = userNotificationSettingRepository.findByUserAndNotificationType(recipient, event.notificationType());
-        isCategoryEnabled = categorySettingOpt.map(UserNotificationSetting::isEnabled).orElse(true);
+        if (event.notificationType().isConfigurable()) {
+            Optional<UserNotificationSetting> categorySettingOpt = userNotificationSettingRepository.findByUserAndNotificationType(recipient, event.notificationType());
+            boolean isCategoryEnabled = categorySettingOpt.map(UserNotificationSetting::isEnabled).orElse(true);
 
-        if (!isCategoryEnabled) {
-            log.info("사용자 ID {}: '{}' 카테고리 스위치 OFF. 푸시 알림을 발송하지 않습니다.", recipient.getId(), event.notificationType());
-            return;
+            if (!isCategoryEnabled) {
+                log.info("사용자 ID {}: '{}' 카테고리 스위치 OFF. 푸시 알림을 발송하지 않습니다.", recipient.getId(), event.notificationType());
+                return;
+            }
         }
 
-        // 3단계: 채팅방별 알림 설정 확인 (채팅 알림인 경우)
         if (event.notificationType() == NotificationType.chat) {
             boolean isRoomNotificationsEnabled;
             Optional<ChatParticipant> participantOpt = chatParticipantRepository.findByChatRoomIdAndUserId(event.referenceId(), recipient.getId());

--- a/src/main/java/core/domain/notification/service/UserNotificationService.java
+++ b/src/main/java/core/domain/notification/service/UserNotificationService.java
@@ -145,4 +145,20 @@ public class UserNotificationService {
 
         notificationRepository.save(notification);
     }
+    /**
+     * 특정 알림을 읽음 상태로 변경합니다.
+     * @param userId         현재 로그인한 사용자의 ID
+     * @param notificationId 읽음 처리할 알림의 ID
+     */
+    public void markNotificationAsRead(Long userId, Long notificationId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOTIFICATION_NOT_FOUND));
+
+        if (!notification.getUser().getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.NOTIFICATION_FORBIDDEN);
+        }
+
+        notification.markAsRead();
+
+    }
 }

--- a/src/main/java/core/domain/post/service/impl/PostServiceImpl.java
+++ b/src/main/java/core/domain/post/service/impl/PostServiceImpl.java
@@ -3,6 +3,7 @@ package core.domain.post.service.impl;
 import core.domain.board.dto.BoardItem;
 import core.domain.board.entity.Board;
 import core.domain.board.repository.BoardRepository;
+import core.domain.notification.dto.NotificationEvent;
 import core.domain.post.dto.*;
 import core.domain.post.entity.BlockPost;
 import core.domain.post.entity.Post;
@@ -10,8 +11,10 @@ import core.domain.post.repository.BlockPostRepository;
 import core.domain.post.repository.PostRepository;
 import core.domain.post.service.PostService;
 import core.domain.user.entity.BlockUser;
+import core.domain.user.entity.Follow;
 import core.domain.user.entity.User;
 import core.domain.user.repository.BlockRepository;
+import core.domain.user.repository.FollowRepository;
 import core.domain.user.repository.UserRepository;
 import core.global.enums.*;
 import core.global.exception.BusinessException;
@@ -27,6 +30,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -53,6 +57,8 @@ public class PostServiceImpl implements PostService {
     private final BlockRepository blockRepository;
     private final BlockPostRepository blockPostRepository;
 
+    private final FollowRepository followRepository;
+    private final ApplicationEventPublisher eventPublisher;
     @Override
     @Transactional(readOnly = true)
     public CursorPageResponse<BoardItem> getPostList(Long boardId, SortOption sort, String cursor, int size) {
@@ -207,8 +213,36 @@ public class PostServiceImpl implements PostService {
         final Post post = getPost(email, request, board);
 
         imageService.saveOrUpdatePostImages(post.getId(), request.imageUrls(), null);
+        publishFollowerNotification(post);
     }
 
+    /**
+     *  [새로 추가된 private 헬퍼 메소드]
+     * 게시글 작성자의 팔로워들에게 알림을 발행합니다.
+     * @param post 새로 작성되고 저장된 게시글 엔티티
+     */
+    private void publishFollowerNotification(Post post) {
+        User author = post.getAuthor();
+        List<Follow> follows = followRepository.findAllByFollowingAndStatus(author, FollowStatus.ACCEPTED);
+
+        for (Follow follow : follows) {
+            User recipient = follow.getUser();
+
+            if (recipient.getId().equals(author.getId())) {
+                continue;
+            }
+
+            NotificationEvent event = new NotificationEvent(
+                    recipient.getId(),
+                    author.getId(),
+                    NotificationType.followuserpost,
+                    post.getId(),
+                    null,
+                    null
+            );
+            eventPublisher.publishEvent(event);
+        }
+    }
     @Override
     @Transactional
     public void writePostForChat(Long roomId, PostWriteForChatRequest request) {

--- a/src/main/java/core/domain/user/repository/FollowRepository.java
+++ b/src/main/java/core/domain/user/repository/FollowRepository.java
@@ -35,7 +35,7 @@ public interface FollowRepository extends JpaRepository<Follow,Long> {
     @Query("SELECT f FROM Follow f JOIN FETCH f.user WHERE f.following = :user AND f.status = :status")
     List<Follow> findByFollowingAndStatus(@Param("user") User user, @Param("status") FollowStatus status);
 
-
+    List<Follow> findAllByFollowingAndStatus(User following, FollowStatus status);
 
     /**
     특정 사용자와 팔로우 대상의 관계를 조회 (상태 무관)

--- a/src/main/java/core/domain/user/repository/UserRepository.java
+++ b/src/main/java/core/domain/user/repository/UserRepository.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Repository;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -86,4 +87,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
   """, nativeQuery = true)
     List<Object[]> countInactive30dAndTotal();
 
+    @Query("SELECT u FROM User u")
+    Stream<User> findAllAsStream();
 }

--- a/src/main/java/core/domain/user/service/UserService.java
+++ b/src/main/java/core/domain/user/service/UserService.java
@@ -9,6 +9,7 @@ import core.domain.chat.repository.ChatMessageRepository;
 import core.domain.chat.repository.ChatParticipantRepository;
 import core.domain.chat.repository.ChatRoomRepository;
 import core.domain.comment.repository.CommentRepository;
+import core.domain.notification.dto.NewUserJoinedEvent;
 import core.domain.post.entity.Post;
 import core.domain.post.repository.BlockPostRepository;
 import core.domain.post.repository.PostRepository;
@@ -622,6 +623,8 @@ public class UserService {
         if (notBlank(dto.imageKey())) {
             imageService.upsertUserProfileImage(user.getId(), dto.imageKey().trim());
         }
+        NewUserJoinedEvent event = new NewUserJoinedEvent(user.getId());
+        eventPublisher.publishEvent(event);
     }
 
 

--- a/src/main/java/core/global/enums/ErrorCode.java
+++ b/src/main/java/core/global/enums/ErrorCode.java
@@ -100,6 +100,9 @@ public enum ErrorCode {
     ALREADY_CHAT_PARTICIPANT(HttpStatus.UNAUTHORIZED, "이미 현재의 그룹채팅방에 참여하고 있습니다."),
     NOT_CHAT_PARTICIPANT(HttpStatus.UNAUTHORIZED, "유저는 현재 채팅방에 참여하고 있지 않습니다."),
 
+    NOTIFICATION_FORBIDDEN(HttpStatus.UNAUTHORIZED, "알람을 받은 유저와 같은 유저가 아닙니다."),
+    NOTIFICATION_NOT_FOUND(HttpStatus.UNAUTHORIZED, "해당 알람을 찾을 수 없습니다."),
+
     JWT_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "인증 정보(JWT)가 필요합니다."),
     JWT_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "액세스 토큰이 만료되었습니다."),
     JWT_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),

--- a/src/main/java/core/global/enums/NotificationType.java
+++ b/src/main/java/core/global/enums/NotificationType.java
@@ -1,5 +1,5 @@
 package core.global.enums;
 
 public enum NotificationType {
-    post,comment,chat,follow,receive
+    post,comment,chat,follow,receive,newuser
 }

--- a/src/main/java/core/global/enums/NotificationType.java
+++ b/src/main/java/core/global/enums/NotificationType.java
@@ -1,5 +1,22 @@
 package core.global.enums;
 
+import lombok.Getter;
+
+@Getter
 public enum NotificationType {
-    post,comment,chat,follow,receive,newuser,followuserpost
+    post(true),
+    comment(true),
+    chat(true),
+    follow(true),
+    receive(true),
+    newuser(false), // 👈 사용자가 설정할 수 없으므로 false
+    followuserpost(true);
+
+    private final boolean configurable;
+
+    NotificationType(boolean configurable) {
+        this.configurable = configurable;
+    }
+
+
 }

--- a/src/main/java/core/global/enums/NotificationType.java
+++ b/src/main/java/core/global/enums/NotificationType.java
@@ -1,5 +1,5 @@
 package core.global.enums;
 
 public enum NotificationType {
-    post,comment,chat,follow,receive,newuser
+    post,comment,chat,follow,receive,newuser,followuserpost
 }

--- a/src/main/java/core/global/enums/NotificationType.java
+++ b/src/main/java/core/global/enums/NotificationType.java
@@ -9,7 +9,7 @@ public enum NotificationType {
     chat(true),
     follow(true),
     receive(true),
-    newuser(false), // 👈 사용자가 설정할 수 없으므로 false
+    newuser(true),
     followuserpost(true);
 
     private final boolean configurable;


### PR DESCRIPTION
# 📄 PR 변경사항
- 팔로우한 사용자의 새 글 작성 시 알림을 발송하는 기능을 추가했습니다.
- 각 채팅방의 알림을 개별적으로 ON/OFF 할 수 있는 기능을 추가했습니다.
- '신규 유저 가입' 알림을 사용자가 설정 화면에서 제어할 수 있도록 변경했습니다.

# 🖌️ 구체적인 구현 내용
**팔로우 사용자 새 글 알림 (followuserpost)**

PostService의 writePost 메소드에서 게시글 저장 후, 작성자를 팔로우하는 모든 유저(ACCEPTED 상태)에게 NotificationEvent를 발행하도록 구현했습니다.

FollowRepository에 팔로워 목록을 조회하는 findAllByFollowingAndStatus 메소드를 추가했습니다.

**채팅방별 알림 설정**

ChatController에 POST /api/v1/chat/rooms/{roomId}/notifications 엔드포인트를 추가했습니다.

ChatService에 toggleChatRoomNotifications 메소드를 구현하여, ChatParticipant 엔티티의 notificationsEnabled 상태를 변경하도록 했습니다. 사용자가 해당 채팅방의 참여자가 아닐 경우 CHAT_PARTICIPANT_NOT_FOUND 예외를 발생시킵니다.

**신규 유저 알림 설정**

NotificationType Enum에 configurable 플래그를 활용하여, newuser 타입도 사용자가 설정 가능한 알림으로 변경했습니다. 이로 인해 별도의 큰 수정 없이 기존 알림 설정 로직에 자연스럽게 통합됩니다.

# ✨개선 사항 및 참고 사항
- NotificationType Enum에 configurable 플래그를 도입하여, 향후 관리자 공지성 알림이나 사용자 선택형 알림이 추가되더라도 유연하게 확장할 수 있는 구조를 마련했습니다.

# 💯 테스트



# 확인
- [ ] 주석 및 print를 제거하셨나요?
- [ ] javaDoc을 작성하셨나요?
- [ ] merge할 브랜치와 로컬에서 merge 하셨나요?
- [ ] 더 수정할 작업은 없는지 확인하셨나요?
