### PR TITLE
feat(notification): 알림 목록 조회 API 구현

### DIFF
--- a/src/main/java/core/domain/notification/controller/UserNotificationController.java
+++ b/src/main/java/core/domain/notification/controller/UserNotificationController.java
@@ -9,6 +9,8 @@ import core.domain.usernotificationsetting.dto.NotificationSettingBulkUpdateRequ
 import core.domain.usernotificationsetting.service.UserNotificationSettingService;
 import core.global.config.CustomUserDetails;
 import core.global.dto.ApiResponse;
+import core.global.enums.NotificationType;
+import core.global.image.dto.NotificationSliceResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -16,6 +18,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -356,5 +361,20 @@ public class UserNotificationController {
     ) {
         userNotificationService.markNotificationAsRead(userDetails.getUserId(), notificationId);
         return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @Operation(summary = "알림 목록 조회", description = "최근 7일간의 알림 목록을 조회합니다. 타입으로 필터링할 수 있습니다.")
+    @GetMapping("/list")
+    public ResponseEntity<ApiResponse<NotificationSliceResponseDto>> getNotifications(
+                                                                                       @AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                                       @RequestParam(required = false) NotificationType type,
+                                                                                       @PageableDefault(size = 20) Pageable pageable
+    ) {
+        NotificationSliceResponseDto response = userNotificationService.getNotifications(
+                userDetails.getUserId(),
+                type,
+                pageable
+        );
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/core/domain/notification/dto/ActorDto.java
+++ b/src/main/java/core/domain/notification/dto/ActorDto.java
@@ -1,0 +1,12 @@
+package core.domain.notification.dto;
+
+
+import core.domain.user.entity.User;
+import lombok.Builder;
+
+@Builder
+public record ActorDto(
+        Long id,
+        String name,
+        String profileImageUrl
+) {}

--- a/src/main/java/core/domain/notification/dto/NotificationResponseDto.java
+++ b/src/main/java/core/domain/notification/dto/NotificationResponseDto.java
@@ -1,0 +1,18 @@
+package core.domain.notification.dto;
+
+import core.global.enums.NotificationType;
+import lombok.Builder;
+
+import java.time.Instant;
+
+@Builder
+public record NotificationResponseDto(
+        Long notificationId,
+        NotificationType notificationType,
+        String message,
+        boolean isRead,
+        Instant createdAt,
+        ActorDto actor,
+        Long referenceId,
+        Long subReferenceId
+) {}

--- a/src/main/java/core/domain/notification/entity/Notification.java
+++ b/src/main/java/core/domain/notification/entity/Notification.java
@@ -42,20 +42,27 @@ public class Notification {
     @Enumerated(EnumType.STRING)
     @Column(name = "notification_type", nullable = false)
     private NotificationType notificationType;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "actor_id")
     private User actor;
+
+    @Column(name = "sub_reference_id")
+    private Long subReferenceId;
+
     @Builder
     public Notification(User user,
                         String message,
                         Long referenceId,
                         NotificationType notificationType,
-                        User actor) {
+                        User actor,
+                        Long subReferenceId) {
         this.user = user;
         this.message = message;
         this.referenceId = referenceId;
         this.notificationType = notificationType;
         this.actor = actor;
+        this.subReferenceId = subReferenceId;
         this.createdAt = Instant.now();
         this.read = false;
     }

--- a/src/main/java/core/domain/notification/entity/Notification.java
+++ b/src/main/java/core/domain/notification/entity/Notification.java
@@ -42,13 +42,20 @@ public class Notification {
     @Enumerated(EnumType.STRING)
     @Column(name = "notification_type", nullable = false)
     private NotificationType notificationType;
-
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "actor_id")
+    private User actor;
     @Builder
-    public Notification(User user, String message, Long referenceId, NotificationType notificationType) {
+    public Notification(User user,
+                        String message,
+                        Long referenceId,
+                        NotificationType notificationType,
+                        User actor) {
         this.user = user;
         this.message = message;
         this.referenceId = referenceId;
         this.notificationType = notificationType;
+        this.actor = actor;
         this.createdAt = Instant.now();
         this.read = false;
     }

--- a/src/main/java/core/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/core/domain/notification/repository/NotificationRepository.java
@@ -2,13 +2,41 @@ package core.domain.notification.repository;
 
 import core.domain.notification.entity.Notification;
 import core.domain.user.entity.User;
+import core.global.enums.NotificationType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.Instant;
 import java.util.List;
 
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
     void deleteAllByUserId(Long userId);
+
+    /**
+     * 특정 사용자의 알림 목록을 조건에 맞게 조회합니다. (페이지네이션 지원)
+     * JOIN FETCH를 사용하여 N+1 문제를 해결합니다.
+     *
+     * @param userId 조회할 사용자의 ID
+     * @param since 데이터를 조회할 시작 시점 (예: 7일 전)
+     * @param notificationType 필터링할 알림 타입 (null일 경우 전체 조회)
+     * @param pageable 페이징 정보 (페이지 번호, 사이즈, 정렬)
+     * @return 페이징 처리된 Notification 목록
+     */
+    @Query("SELECT n FROM Notification n JOIN FETCH n.actor " +
+            "WHERE n.user.id = :userId " +
+            "AND n.createdAt >= :since " +
+            "AND (:notificationType IS NULL OR n.notificationType = :notificationType) " +
+            "ORDER BY n.createdAt DESC")
+    Page<Notification> findNotificationsByUserId(
+            @Param("userId") Long userId,
+            @Param("since") Instant since,
+            @Param("notificationType") NotificationType notificationType,
+            Pageable pageable
+    );
 }

--- a/src/main/java/core/domain/notification/service/NotificationEventListener.java
+++ b/src/main/java/core/domain/notification/service/NotificationEventListener.java
@@ -43,7 +43,7 @@ public class NotificationEventListener {
             log.info("알림 이벤트 수신: recipientId={}, actorId={}", recipient.getId(), actor.getId());
 
             String message = notificationMessageGenerator.generateMessage(actor, event);
-            notificationService.createAndSaveNotification(recipient, event, message);
+            notificationService.createAndSaveNotification(recipient, actor, event, message);
             pushNotificationService.sendPushNotification(recipient, event, message);
 
         } catch (Exception e) {
@@ -83,7 +83,7 @@ public class NotificationEventListener {
             }
 
             try {
-                notificationService.createAndSaveNotification(recipient, tempEvent, message);
+                notificationService.createAndSaveNotification(recipient, newUserActor, tempEvent, message);
                 pushNotificationService.sendPushNotification(recipient, tempEvent, message);
             } catch (Exception e) {
                 log.error("사용자 ID {}에게 신규 유저 알림 발송 중 오류 발생", recipient.getId(), e);

--- a/src/main/java/core/domain/notification/service/UserNotificationService.java
+++ b/src/main/java/core/domain/notification/service/UserNotificationService.java
@@ -146,6 +146,7 @@ public class UserNotificationService {
                 .notificationType(event.notificationType())
                 .referenceId(event.referenceId())
                 .actor(actor)
+                .subReferenceId(event.commentId())
                 .build();
 
         notificationRepository.save(notification);

--- a/src/main/java/core/domain/notification/service/UserNotificationService.java
+++ b/src/main/java/core/domain/notification/service/UserNotificationService.java
@@ -134,13 +134,18 @@ public class UserNotificationService {
      * @param event     알림 이벤트 데이터 (ID 값들을 담고 있음)
      * @param message   최종적으로 생성된 메시지 문자열
      */
-    // ✅ User 객체를 직접 파라미터로 받도록 변경
-    public void createAndSaveNotification(User recipient, NotificationEvent event, String message) {
+    @Transactional
+    public void createAndSaveNotification(User recipient,
+                                          User actor,
+                                          NotificationEvent event,
+                                          String message) {
+
         Notification notification = Notification.builder()
-                .user(recipient) // 전달받은 User 엔티티를 그대로 사용
+                .user(recipient)
                 .message(message)
-                .referenceId(event.referenceId())
                 .notificationType(event.notificationType())
+                .referenceId(event.referenceId())
+                .actor(actor)
                 .build();
 
         notificationRepository.save(notification);

--- a/src/main/java/core/domain/notification/service/UserNotificationService.java
+++ b/src/main/java/core/domain/notification/service/UserNotificationService.java
@@ -1,9 +1,7 @@
 package core.domain.notification.service;
 
-import core.domain.notification.dto.NotificationEvent;
-import core.domain.notification.dto.NotificationSettingListResponse;
-import core.domain.notification.dto.NotificationSettingResponse;
-import core.domain.notification.dto.NotificationSettingStatusResponse;
+import com.google.cloud.PageImpl;
+import core.domain.notification.dto.*;
 import core.domain.notification.entity.Notification;
 import core.domain.notification.repository.NotificationRepository;
 import core.domain.user.entity.User;
@@ -13,15 +11,25 @@ import core.domain.userdevicetoken.repository.UserDeviceTokenRepository;
 import core.domain.usernotificationsetting.entity.UserNotificationSetting;
 import core.domain.usernotificationsetting.repository.UserNotificationSettingRepository;
 import core.global.enums.ErrorCode;
+import core.global.enums.ImageType;
 import core.global.enums.NotificationType;
 import core.global.exception.BusinessException;
+import core.global.image.dto.NotificationSliceResponseDto;
+import core.global.image.entity.Image;
+import core.global.image.repository.ImageRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList; // ArrayList import 추가
 import java.util.List;
+import java.util.Map;
 import java.util.Optional; // Optional import 추가
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -32,6 +40,7 @@ public class UserNotificationService {
     private final UserDeviceTokenRepository userDeviceTokenRepository;
     private final UserNotificationSettingRepository userNotificationSettingRepository;
     private final NotificationRepository notificationRepository;
+    private final ImageRepository imageRepository;
     /**
      * FCM 기기 토큰을 등록하거나 갱신합니다. (람다 제거 버전)
      */
@@ -166,5 +175,69 @@ public class UserNotificationService {
 
         notification.markAsRead();
 
+    }
+
+    public NotificationSliceResponseDto getNotifications(Long userId, NotificationType type, Pageable pageable) {
+        Instant sevenDaysAgo = Instant.now().minus(7, ChronoUnit.DAYS);
+
+        Page<Notification> notificationPage = notificationRepository.findNotificationsByUserId(
+                userId, sevenDaysAgo, type, pageable
+        );
+
+        List<Notification> notifications = notificationPage.getContent();
+        if (notifications.isEmpty()) {
+            return NotificationSliceResponseDto.builder()
+                    .notifications(List.of())
+                    .hasNext(false)
+                    .build();
+        }
+
+        List<Long> actorIds = notifications.stream()
+                .map(n -> n.getActor().getId())
+                .distinct()
+                .toList();
+
+        Map<Long, Image> firstImageMap = imageRepository.findByImageTypeAndRelatedIdIn(ImageType.USER, actorIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        Image::getRelatedId,
+                        image -> image,
+                        (img1, img2) -> img1.getOrderIndex() < img2.getOrderIndex() ? img1 : img2
+                ));
+
+        List<NotificationResponseDto> dtos = notifications.stream()
+                .map(notification -> {
+                    User actor = notification.getActor();
+                    Image profileImage = firstImageMap.get(actor.getId());
+                    String profileImageUrl = (profileImage != null) ? profileImage.getUrl() : null;
+
+                    ActorDto actorDto = ActorDto.builder()
+                            .id(actor.getId())
+                            .name(actor.getFirstName())
+                            .profileImageUrl(profileImageUrl)
+                            .build();
+
+                    return NotificationResponseDto.builder()
+                            .notificationId(notification.getId())
+                            .message(notification.getMessage())
+                            .isRead(notification.isRead())
+                            .createdAt(notification.getCreatedAt())
+                            .actor(actorDto)
+                            .referenceId(notification.getReferenceId())
+                            .subReferenceId(notification.getSubReferenceId())
+                            .build();
+                })
+                .toList();
+
+        String nextCursor = null;
+        if (notificationPage.hasNext()) {
+            nextCursor = notifications.get(notifications.size() - 1).getCreatedAt().toString();
+        }
+
+        return NotificationSliceResponseDto.builder()
+                .notifications(dtos)
+                .hasNext(notificationPage.hasNext())
+                .nextCursor(nextCursor)
+                .build();
     }
 }

--- a/src/main/java/core/domain/user/service/FollowService.java
+++ b/src/main/java/core/domain/user/service/FollowService.java
@@ -54,7 +54,6 @@ public class FollowService {
                 .followerSex(follower.getSex())
                 .followerBirthdate(follower.getBirthdate())
                 .followerLanguage(follower.getLanguage())
-                // 팔로잉 정보 스냅샷
                 .followingIsInKorea(following.isInKorea())
                 .followingCountry(following.getCountry())
                 .followingSex(following.getSex())

--- a/src/main/java/core/global/image/dto/NotificationSliceResponseDto.java
+++ b/src/main/java/core/global/image/dto/NotificationSliceResponseDto.java
@@ -1,0 +1,18 @@
+package core.global.image.dto;
+
+import core.domain.notification.dto.NotificationResponseDto;
+import lombok.Builder;
+import java.util.List;
+
+/**
+ * 알림 목록 조회를 위한 슬라이스 기반 응답 DTO (커서 기반 페이지네이션)
+ * @param notifications 알림 데이터 목록
+ * @param nextCursor 다음 페이지를 조회하기 위한 커서 (마지막 알림의 생성 시간)
+ * @param hasNext 다음 페이지 존재 여부
+ */
+@Builder
+public record NotificationSliceResponseDto(
+        List<NotificationResponseDto> notifications,
+        String nextCursor,
+        boolean hasNext
+) {}

--- a/src/main/java/core/global/image/repository/ImageRepository.java
+++ b/src/main/java/core/global/image/repository/ImageRepository.java
@@ -93,4 +93,6 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
      * 채팅방의 기존 이미지를 모두 삭제하기 위해 사용됩니다.
      */
     List<Image> findByImageTypeAndRelatedId(ImageType imageType, Long relatedId);
+
+    List<Image> findByImageTypeAndRelatedIdIn(ImageType imageType, List<Long> relatedIds);
 }

--- a/src/main/resources/db/migration/V202051020_03__Add_actor_id_to_notification.sql
+++ b/src/main/resources/db/migration/V202051020_03__Add_actor_id_to_notification.sql
@@ -1,0 +1,6 @@
+ALTER TABLE notification
+    ADD COLUMN actor_id BIGINT NULL;
+
+ALTER TABLE notification
+    ADD CONSTRAINT fk_notification_actor
+        FOREIGN KEY (actor_id) REFERENCES users(user_id);

--- a/src/main/resources/db/migration/V202051020_04__Add_profile_image_and_sub_ref_id.sql
+++ b/src/main/resources/db/migration/V202051020_04__Add_profile_image_and_sub_ref_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE notification
+    ADD COLUMN sub_reference_id BIGINT NULL;


### PR DESCRIPTION
📄 PR 변경사항
알림 목록 조회 API를 구현했습니다.

사용자는 자신의 계정으로 수신된 최근 7일간의 알림을 커서 기반 페이지네이션으로 조회할 수 있습니다.

알림 타입(NotificationType)별 필터링 기능을 추가했습니다.

🖌️ 구체적인 구현 내용
GET /api/v1/user/notification/list 엔드포인트를 UserNotificationController에 추가했습니다.

Pageable을 통해 페이지 크기와 시작점을 받고, NotificationSliceResponseDto를 반환하여 무한 스크롤에 최적화된 응답을 제공합니다.

응답 DTO는 알림 리스트(notifications), 다음 페이지 존재 여부(hasNext), 그리고 다음 페이지를 요청할 때 사용할 커서(nextCursor)를 포함합니다.

성능 최적화 (N+1 문제 해결)

NotificationRepository에서 @Query와 JOIN FETCH를 사용하여 알림과 알림을 보낸 행위자(Actor) 정보를 한 번의 쿼리로 조회했습니다.

행위자의 프로필 이미지는 별도의 Image 테이블에서 관리되므로, 조회된 모든 행위자의 ID를 수집하여 IN 절을 통해 단 한 번의 추가 쿼리로 모든 프로필 이미지를 조회했습니다.

한 명의 유저가 여러 프로필 이미지를 가질 경우, orderIndex가 가장 낮은 이미지를 대표 이미지로 사용하도록 로직을 구현했습니다.

✨개선 사항 및 참고 사항
이번 API 구현을 통해 기존에 발생할 수 있었던 알림 조회 -> (알림 개수만큼) 행위자 조회 -> (행위자 수만큼) 이미지 조회로 이어지는 심각한 N+1 문제를 선제적으로 방지했습니다.

클라이언트는 첫 요청 후, 응답으로 받은 nextCursor 값을 다음 요청 시 page 파라미터 대신 사용하여 다음 페이지의 데이터를 원활하게 로드할 수 있습니다.

💯 테스트
Postman을 통해 API가 정상적으로 동작하는 것을 확인했습니다.

1. 첫 페이지 조회 (타입 필터링 없음)

Request: GET /api/v1/user/notification/list?size=10

Response: hasNext: true 와 함께 nextCursor 값이 반환되는 것을 확인했습니다. 각 알림 항목에 actor의 id, name, profileImageUrl이 정상적으로 포함된 것을 확인했습니다.

2. post 타입 알림만 필터링하여 조회

Request: GET /api/v1/user/notification/list?size=10&type=post

Response: notificationType이 post인 알림만 필터링되어 반환되는 것을 확인했습니다.

3. 다음 페이지 조회 (커서 사용)

Request: GET /api/v1/user/notification/list?size=10&page={1번-응답에서-받은-nextCursor-값}

Response: 다음 페이지의 데이터가 정상적으로 반환되는 것을 확인했습니다.

확인
[ ] 주석 및 print를 제거하셨나요?

[ ] javaDoc을 작성하셨나요?

[ ] merge할 브랜치와 로컬에서 merge 하셨나요?

[ ] 더 수정할 작업은 없는지 확인하셨나요?