### PR TITLE
feat: 자동완성 + 추천검색어 제공

### DIFF
--- a/src/main/java/core/domain/post/controller/PostSearchController.java
+++ b/src/main/java/core/domain/post/controller/PostSearchController.java
@@ -1,12 +1,21 @@
 package core.domain.post.controller;
 
+import core.domain.post.dto.PostDetailResponse;
+import core.domain.post.dto.SearchResultView;
+import core.domain.post.dto.SuggestClickRequest;
 import core.domain.post.service.PostSearchService;
+import core.domain.post.service.PostService;
+import core.domain.post.service.RecentSearchRedisService;
+import core.domain.post.service.SuggestMemoryIndex;
 import core.global.dto.ApiResponse;
 import core.global.metrics.FeatureUsageMetrics;
 import core.global.pagination.CursorPageResponse;
-import core.domain.post.dto.SearchResultView;
-import core.domain.post.service.RecentSearchRedisService;
+import core.global.service.SimpleKeywordExtractor;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -18,12 +27,18 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/search")
 @RequiredArgsConstructor
+@Tag(name = "Search", description = "게시글 검색/자동완성/최근 검색어 API")
 public class PostSearchController {
 
+    private final PostService postService;
     private final PostSearchService searchService;
     private final RecentSearchRedisService recentService;
     private final FeatureUsageMetrics featureUsageMetrics;
+    private final SuggestMemoryIndex memoryIndex;
+    private final SimpleKeywordExtractor keywordExtractor;
 
+    @Operation(summary = "게시글 검색", description = "커서 페이지네이션 지원")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공")
     @GetMapping("/{boardId}/posts")
     public ResponseEntity<ApiResponse<CursorPageResponse<SearchResultView>>> getPostList(
             @RequestParam String q,
@@ -39,28 +54,66 @@ public class PostSearchController {
                 ));
     }
 
+    @Operation(summary = "검색결과 클릭 텔레메트리",
+            description = "사용자가 검색결과를 클릭/열람했을 때 호출하여 인기(pop) 점수를 반영합니다.")
+    @GetMapping("/{boardId}/posts/{postId}")
+    public ResponseEntity<core.global.dto.ApiResponse<PostDetailResponse>> resultClicked(
+            @Parameter(description = "보드 ID(1=전체)") @PathVariable Long boardId,
+            @Parameter(description = "게시글 ID", example = "123") @PathVariable @Positive Long postId
+    ) {
+        featureUsageMetrics.recordCommunityUsage();
+        PostDetailResponse postDetail = postService.getPostDetail(postId);
+
+        extractedKeyword(postDetail.content(),1);
+
+        return ResponseEntity.ok(core.global.dto.ApiResponse.success(postDetail));
+    }
+
+    @Operation(summary = "자동완성 제안", description = "메모리+DB 하이브리드")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공")
     @GetMapping("/{boardId}/suggest")
-    public List<String> suggestByBoard(@PathVariable Long boardId,
-                                       @RequestParam("q") String q) {
+    public List<String> suggestByBoard(@PathVariable Long boardId, @RequestParam("q") String q) {
         featureUsageMetrics.recordCommunityUsage();
         return searchService.suggest(q, boardId);
     }
 
+    @Operation(summary = "자동완성 클릭 기록")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공")
+    @PostMapping("/clicked")
+    public void clicked(@RequestBody @Valid SuggestClickRequest body) {
+        extractedKeyword(body.text(),1);
+    }
+
+    @Operation(summary = "최근 검색어 조회")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공")
     @GetMapping("/recent")
     public List<String> recent() {
         featureUsageMetrics.recordCommunityUsage();
         return recentService.list();
     }
 
+    @Operation(summary = "최근 검색어 단건 삭제")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공")
     @DeleteMapping("/recent")
     public void deleteRecent(@RequestParam String q) {
         featureUsageMetrics.recordCommunityUsage();
         recentService.remove(q);
     }
 
+    @Operation(summary = "최근 검색어 전체 삭제")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공")
     @DeleteMapping("/recent/all")
     public void clearRecent() {
         featureUsageMetrics.recordCommunityUsage();
         recentService.clear();
+    }
+
+    private void extractedKeyword(String content, int score) {
+        if (content != null && !content.isBlank()) {
+            // 상위 K만 반영
+            int K = 8;
+            var phrases = keywordExtractor.extract(content, K);
+            phrases.forEach(p -> memoryIndex.upsert(p, score));
+        }
     }
 }

--- a/src/main/java/core/domain/post/dto/SuggestClickRequest.java
+++ b/src/main/java/core/domain/post/dto/SuggestClickRequest.java
@@ -1,0 +1,11 @@
+package core.domain.post.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record SuggestClickRequest(
+        @NotBlank
+        @Schema(description = "본문", example = "첫 글입니다! 반가워요 :)")
+        String text
+) {
+}

--- a/src/main/java/core/domain/post/event/PostCreatedEvent.java
+++ b/src/main/java/core/domain/post/event/PostCreatedEvent.java
@@ -1,0 +1,3 @@
+package core.domain.post.event;
+
+public record PostCreatedEvent(Long postId, String content) {}

--- a/src/main/java/core/domain/post/event/PostUpdatedEvent.java
+++ b/src/main/java/core/domain/post/event/PostUpdatedEvent.java
@@ -1,0 +1,3 @@
+package core.domain.post.event;
+
+public record PostUpdatedEvent(Long postId, String content) {}

--- a/src/main/java/core/domain/post/listener/PostIndexingListener.java
+++ b/src/main/java/core/domain/post/listener/PostIndexingListener.java
@@ -1,0 +1,38 @@
+package core.domain.post.listener;
+
+import core.domain.post.event.PostCreatedEvent;
+import core.domain.post.event.PostUpdatedEvent;
+import core.domain.post.service.SuggestMemoryIndex;
+import core.global.service.SimpleKeywordExtractor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class PostIndexingListener {
+
+    private final SuggestMemoryIndex memoryIndex;
+    private final SimpleKeywordExtractor keywordExtractor;
+
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onCreated(PostCreatedEvent e) {
+        if (e.content() != null) extractedKeyword(e.content(), 5);
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onUpdated(PostUpdatedEvent e) {
+        if (e.content() != null) extractedKeyword(e.content(), 3);
+    }
+
+    private void extractedKeyword(String content, int score) {
+        if (content != null && !content.isBlank()) {
+            // 상위 K만 반영
+            int K = 8;
+            var phrases = keywordExtractor.extract(content, K);
+            phrases.forEach(p -> memoryIndex.upsert(p, score));
+        }
+    }
+}

--- a/src/main/java/core/domain/post/repository/PostSearchRepositoryCustom.java
+++ b/src/main/java/core/domain/post/repository/PostSearchRepositoryCustom.java
@@ -8,6 +8,6 @@ import java.util.List;
 public interface PostSearchRepositoryCustom {
     List<String> suggest(String q, Long resolvedBoardId, List<Long> blockedIds, int limit);
     List<SearchResultView> search(String q, Long resolvedBoardId, List<Long> blockedIds, Instant afterTime, Long afterId, int i);
-
+    List<String> findHotKeywordsOrTitles(int topN);
 }
 

--- a/src/main/java/core/domain/post/repository/PostSearchRepositoryCustomImpl.java
+++ b/src/main/java/core/domain/post/repository/PostSearchRepositoryCustomImpl.java
@@ -5,8 +5,10 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import core.domain.post.entity.QPost;
 import core.domain.post.dto.SearchResultView;
+import core.domain.post.entity.QPost;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -17,7 +19,10 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PostSearchRepositoryCustomImpl implements PostSearchRepositoryCustom {
 
-    private final JPAQueryFactory qf;
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @PersistenceContext
+    private final EntityManager entityManager;
 
     /**
      * 정확도 정렬 1종 + 키셋 커서(score, created_at, post_id) 역순
@@ -70,12 +75,12 @@ public class PostSearchRepositoryCustomImpl implements PostSearchRepositoryCusto
         // 미리보기 텍스트 200자
         var preview200 = Expressions.stringTemplate("function('left', {0}, 200)", p.content);
 
-        return qf
+        return jpaQueryFactory
                 .select(Projections.constructor(SearchResultView.class,
                         Projections.constructor(core.domain.board.dto.BoardItem.class,
                                 p.id,                         // postId
                                 preview200,                   // contentPreview
-                                Expressions.nullExpression(String.class), // title 등 필요 없으면 null
+                                Expressions.nullExpression(String.class), // content 등 필요 없으면 null
                                 p.board.category,
                                 p.createdAt,
                                 Expressions.constant(false),  // isSomething(ex: bookmarked) 없으면 기본값
@@ -95,6 +100,50 @@ public class PostSearchRepositoryCustomImpl implements PostSearchRepositoryCusto
                 .limit(limit)
                 .fetch();
     }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public List<String> findHotKeywordsOrTitles(int topN) {
+        String sql = """
+                WITH docs AS (
+                  SELECT p.post_id AS doc_id, p.post_content
+                  FROM public.post p
+                  WHERE p.created_at >= now() - interval '90 days'
+                ),
+                tokens AS (
+                  SELECT d.doc_id, w.term
+                  FROM docs d
+                  CROSS JOIN LATERAL unnest(
+                    pgroonga_tokenize(
+                      d.post_content,
+                      'tokenizer','TokenDelimit'     -- ★ 단어 단위 토크나이저
+                    )
+                  ) AS t(token_json)
+                  /* term을 LATERAL 서브셀렉트에서 컬럼으로 만든다 */
+                  CROSS JOIN LATERAL (
+                    SELECT lower(btrim((t.token_json::jsonb ->> 'value'))) AS term
+                  ) AS w
+                  WHERE w.term <> ''
+                    AND w.term !~ '\\s'               -- 공백 포함 토큰 제거
+                    AND length(w.term) BETWEEN 2 AND 20
+                    AND w.term !~ '^[0-9]+$'
+                    AND w.term !~ '^(https?://|www\\\\.)'
+                    AND w.term !~ '^[[:punct:]]+$'
+                )
+                SELECT term
+                FROM tokens
+                GROUP BY term
+                HAVING COUNT(DISTINCT doc_id) >= 1   -- 문서 수 기준 빈도
+                ORDER BY COUNT(DISTINCT doc_id) DESC
+                LIMIT :topN
+                """;
+
+
+        return entityManager.createNativeQuery(sql)
+                .setParameter("topN", topN)
+                .getResultList();
+    }
+
 
     /**
      * 자동완성:
@@ -125,7 +174,7 @@ public class PostSearchRepositoryCustomImpl implements PostSearchRepositoryCusto
         );
         var maxCreatedAt = Expressions.dateTimeTemplate(Instant.class, "max({0})", p.createdAt);
 
-        return qf.select(snippet140)
+        return jpaQueryFactory.select(snippet140)
                 .from(p)
                 .where(where)
                 .groupBy(snippet140)

--- a/src/main/java/core/domain/post/service/PostSearchService.java
+++ b/src/main/java/core/domain/post/service/PostSearchService.java
@@ -19,9 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.util.Base64;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -32,7 +30,12 @@ public class PostSearchService {
     private final BlockRepository blockRepository;
     private final UserRepository userRepository;
 
-    private static final int LIMIT = 5;
+    private final SuggestMemoryIndex memoryIndex;
+
+    private static final int LIMIT = 7;
+
+    private static final int FAST_FIRST_MAX = 4;   // 메모리 최대
+    private static final int DB_FALLBACK_MAX = 3;  // DB 최대
 
     @Transactional(readOnly = true)
     public CursorPageResponse<SearchResultView> search(
@@ -88,8 +91,27 @@ public class PostSearchService {
         List<Long> blockedIds = blockRepository.getBlockUsersByUserEmail(email)
                 .stream().map(User::getId).toList();
 
-        // 리포지토리 위임
-        return searchRepository.suggest(pfx, resolvedBoardId, blockedIds, LIMIT);
+        // 1) 메모리 자동완성 우선 (최대 FAST_FIRST_MAX, 단 총 LIMIT 고려)
+        int fastQuota = Math.min(FAST_FIRST_MAX, LIMIT);
+        List<String> fast = memoryIndex.suggestPrefix(pfx, fastQuota);
+
+        // 2) 부족분만 PGroonga로 보충 (최대 DB_FALLBACK_MAX, 단 총 LIMIT 고려)
+        int remain = Math.max(0, LIMIT - fast.size());
+        int dbQuota = Math.min(DB_FALLBACK_MAX, remain);
+
+        List<String> db = List.of();
+        if (dbQuota > 0) {
+            db = searchRepository.suggest(pfx, resolvedBoardId, blockedIds, dbQuota);
+        }
+
+        // 3) 머지: 메모리 우선 순서 보존 + 중복 제거 + 총 LIMIT 절단
+        LinkedHashSet<String> merged = new LinkedHashSet<>(fast);
+        for (String s : db) {
+            if (merged.size() >= LIMIT) break;
+            merged.add(s);
+        }
+
+        return new ArrayList<>(merged);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/core/domain/post/service/SuggestMemoryIndex.java
+++ b/src/main/java/core/domain/post/service/SuggestMemoryIndex.java
@@ -1,0 +1,59 @@
+package core.domain.post.service;
+
+import org.springframework.stereotype.Component;
+
+import java.text.Normalizer;
+import java.util.*;
+import java.util.concurrent.ConcurrentSkipListMap;
+
+/**
+ * 매우 단순한 prefix 사전:
+ * - 키: 텍스트(제목/검색어/태그 등 짧은 후보)
+ * - 값: 인기(pop) 점수
+ * - prefix 조회는 정렬맵의 tailMap으로 근사
+ */
+@Component
+public class SuggestMemoryIndex {
+
+    // 사전: 사전순 정렬을 위해 SkipListMap 사용 (스레드-세이프 변형)
+    private final ConcurrentSkipListMap<String, Integer> dict = new ConcurrentSkipListMap<>();
+
+    /** prefix 기반 빠른 후보(정렬: pop desc → 길이 asc → 사전식) */
+    public List<String> suggestPrefix(String prefix, int limit) {
+        if (prefix == null || prefix.isBlank() || limit <= 0) return List.of();
+
+        var it = dict.tailMap(prefix, true).entrySet().iterator();
+        List<Map.Entry<String, Integer>> buf = new ArrayList<>(limit * 4);
+
+        while (it.hasNext() && buf.size() < limit * 8) {
+            var e = it.next();
+            String key = e.getKey();
+            if (!key.startsWith(prefix)) break;
+            buf.add(e);
+        }
+
+        buf.sort((a, b) -> {
+            int c = Integer.compare(b.getValue(), a.getValue()); // pop desc
+            if (c != 0) return c;
+            int c2 = Integer.compare(a.getKey().length(), b.getKey().length());
+            if (c2 != 0) return c2;
+            return a.getKey().compareTo(b.getKey());
+        });
+
+        return buf.stream().limit(limit).map(Map.Entry::getKey).toList();
+    }
+
+    /** 배치/실시간으로 후보 적재/점수 업데이트 */
+    public void upsert(String text, int deltaPop) {
+        String k = norm(text);
+        if (k == null || k.isBlank()) return;
+        dict.merge(k, deltaPop, Integer::sum);
+    }
+
+    private static String norm(String s) {
+        if (s == null) return null;
+        // 공백 트림 + 소문자 + NFC 정규화
+        return Normalizer.normalize(s.trim().toLowerCase(Locale.ROOT), Normalizer.Form.NFC);
+    }
+
+}

--- a/src/main/java/core/domain/post/service/impl/PostServiceImpl.java
+++ b/src/main/java/core/domain/post/service/impl/PostServiceImpl.java
@@ -7,6 +7,8 @@ import core.domain.notification.dto.NotificationEvent;
 import core.domain.post.dto.*;
 import core.domain.post.entity.BlockPost;
 import core.domain.post.entity.Post;
+import core.domain.post.event.PostCreatedEvent;
+import core.domain.post.event.PostUpdatedEvent;
 import core.domain.post.repository.BlockPostRepository;
 import core.domain.post.repository.PostRepository;
 import core.domain.post.service.PostService;
@@ -293,6 +295,7 @@ public class PostServiceImpl implements PostService {
             throw new BusinessException(ErrorCode.PROFILE_SET_NOT_COMPLETED);
         }
         final Post post = new Post(request, user, board);
+        eventPublisher.publishEvent(new PostCreatedEvent(post.getId(), post.getContent()));
 
         return postRepository.save(post);
     }
@@ -305,6 +308,7 @@ public class PostServiceImpl implements PostService {
             throw new BusinessException(ErrorCode.PROFILE_SET_NOT_COMPLETED);
         }
         final Post post = new Post(request, user, board);
+        eventPublisher.publishEvent(new PostCreatedEvent(post.getId(), post.getContent()));
 
         return postRepository.save(post);
     }
@@ -333,6 +337,8 @@ public class PostServiceImpl implements PostService {
         }
 
         imageService.saveOrUpdatePostImages(post.getId(), request.images(), request.removedImages());
+        eventPublisher.publishEvent(new PostUpdatedEvent(post.getId(), post.getContent()));
+
     }
 
     @Override

--- a/src/main/java/core/global/initializer/SuggestWarmupConfig.java
+++ b/src/main/java/core/global/initializer/SuggestWarmupConfig.java
@@ -1,0 +1,39 @@
+package core.global.initializer;
+
+import core.domain.post.repository.PostSearchRepositoryCustom;
+import core.domain.post.service.SuggestMemoryIndex;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class SuggestWarmupConfig {
+
+    private final PostSearchRepositoryCustom searchRepository;
+    private final SuggestMemoryIndex memoryIndex;
+
+    @Bean
+    ApplicationRunner suggestWarmupRunner() {
+    log.info("runner start");
+        return args -> {
+            int topN = 2000;
+            List<String> hotKeys = searchRepository.findHotKeywordsOrTitles(topN);
+            // --- 확인 로그 ---
+            System.out.println("[Warmup] hotKeys size = " + (hotKeys == null ? 0 : hotKeys.size()));
+            hotKeys.stream().limit(10).forEach(k -> System.out.println("[Warmup] sample=" + k));
+
+            for (String k : hotKeys) {
+                memoryIndex.upsert(k, 1);
+            }
+            // memoryIndex 내부 카운트/크기 노출용 임시 메서드가 없다면 추가 권장
+            System.out.println("[Warmup] memoryIndex loaded.");
+        };
+
+    }
+}

--- a/src/main/java/core/global/service/SimpleKeywordExtractor.java
+++ b/src/main/java/core/global/service/SimpleKeywordExtractor.java
@@ -1,0 +1,115 @@
+package core.global.service;
+
+import org.springframework.stereotype.Component;
+
+import java.text.Normalizer;
+import java.util.*;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+@Component
+public class SimpleKeywordExtractor {
+
+    private static final Pattern TOKEN = Pattern.compile("[\\p{IsHan}\\p{IsHangul}\\p{IsAlphabetic}\\p{IsDigit}]+");
+    private static final Pattern NUMERIC_ONLY = Pattern.compile("^[0-9]+$");
+    private static final Pattern REPEAT_RUN = Pattern.compile("(.)\\1{2,}"); // 같은 문자 3회 이상 연속 (ㅋㅋㅋ, aaa, !!!)
+
+    public List<String> extract(String content, int maxCandidates) {
+        if (content == null) return List.of();
+
+        String norm = Normalizer.normalize(content, Normalizer.Form.NFC)
+                .replaceAll("\\s+", " ")
+                .trim();
+        if (norm.isBlank()) return List.of();
+
+        // 1) 토큰화 + 1차 휴리스틱 필터
+        List<String> toks = new ArrayList<>();
+        var m = TOKEN.matcher(norm);
+        while (m.find()) {
+            String t = m.group().toLowerCase(Locale.ROOT);
+            if (t.length() < 2 || t.length() > 20) continue;
+            if (NUMERIC_ONLY.matcher(t).matches()) continue;      // 숫자-only 배제
+            if (REPEAT_RUN.matcher(t).find()) continue;           // 반복문자 배제
+            if (!diverseEnough(t)) continue;                      // 문자 다양성(엔트로피 대용) 컷
+            toks.add(t);
+        }
+        if (toks.isEmpty()) return List.of();
+
+        // 2) unigram + bigram 스코어링
+        Map<String, Score> scores = new HashMap<>();
+        for (int i = 0; i < toks.size(); i++) {
+            String uni = toks.get(i);
+            bump(scores, uni, i, /*bigram*/ false);
+            if (i + 1 < toks.size()) {
+                String bi = uni + " " + toks.get(i + 1);
+                if (validBigram(bi)) {
+                    bump(scores, bi, i, /*bigram*/ true);
+                }
+            }
+        }
+
+        // 3) 정렬: 점수 desc → 길이 asc → 사전식
+        List<Map.Entry<String, Score>> ranked = scores.entrySet().stream()
+                .sorted((a, b) -> {
+                    int c = Double.compare(b.getValue().score(), a.getValue().score());
+                    if (c != 0) return c;
+                    int c2 = Integer.compare(a.getKey().length(), b.getKey().length());
+                    return (c2 != 0) ? c2 : a.getKey().compareTo(b.getKey());
+                })
+                .toList();
+
+        // 4) 상위 N 반환
+        return ranked.stream()
+                .map(Map.Entry::getKey)
+                .limit(maxCandidates)
+                .collect(Collectors.toList());
+    }
+
+    // 문자 다양성(간이 엔트로피): 유니크 문자 비율이 너무 낮으면 제외
+    private boolean diverseEnough(String t) {
+        // 예: "ㅋㅋㅋㅋ" 같은 단조 패턴 컷
+        int unique = (int) t.chars().distinct().count();
+        double ratio = unique / (double) t.length();
+        return ratio >= 0.3; // 0.3~0.35 사이로 튜닝 권장
+    }
+
+    private boolean validBigram(String bi) {
+        // 양 끝 공백/중복 공백 방지, 숫자-only bigram 방지
+        if (bi.isBlank()) return false;
+        if (NUMERIC_ONLY.matcher(bi.replace(" ", "")).matches()) return false;
+        return true;
+    }
+
+    private void bump(Map<String, Score> map, String key, int pos, boolean bigram) {
+        Score s = map.getOrDefault(key, new Score());
+        // TF 상한으로 과다 반복 방지 (문서 내 같은 토큰 5회까지만 기여)
+        if (s.tf < 5) s.tf += 1;
+        s.firstPos = Math.min(s.firstPos, pos);
+        if (bigram) s.bigramBonus = 1.2; // bigram 우대(가중치 1.0 + 0.2)
+        s.diversity = Math.max(s.diversity, diversity(key));
+        map.put(key, s);
+    }
+
+    // 키 전체의 다양성(공백 포함), 점수 보정에 사용
+    private double diversity(String key) {
+        String k = key.replace(" ", "");
+        int unique = (int) k.chars().distinct().count();
+        return unique / (double) Math.max(1, k.length());
+    }
+
+    private static class Score {
+        int tf = 0;
+        int firstPos = Integer.MAX_VALUE;
+        double bigramBonus = 1.0;
+        double diversity = 0.0;
+
+        double score() {
+            // 위치 보너스: 앞부분 등장 가중(최대 1.5배)
+            double posBonus = 1.0 + Math.max(0, 10 - Math.min(firstPos, 10)) * 0.05;
+            // 다양성 보너스: 0~0.5 가산
+            double diversityBonus = 1.0 + Math.min(0.5, diversity * 0.5);
+            // 최종
+            return tf * posBonus * bigramBonus * diversityBonus;
+        }
+    }
+}


### PR DESCRIPTION
# 📄 PR 변경사항
- 

# 🖌️ 구체적인 구현 내용
<!--  어떤 점을 고려하여 구현하였는지, 어떤 예외를 던지는지 등의 내용을 알려주세요! -->
- 기존에는 게시물 내용을 몇개 제공하는 자동완성 구조였습니다.
- 구글 자동완성처럼 입력 단어마다 자동완성을 제공합니다.
- ConcurrentSkipListMap<값, 점수>의 형태로 메모리에 적재합니다.
- 초기 스프링부트 구동 시에 단어를 뽑아냅니다.
- 게시물 쓰기, 업데이트 시에 이벤트를 발행해 추가합니다.

- 시간 복잡도와 실전 성능의 균형
조회/삽입/삭제가 평균 O(log N).
별도 인덱스 관리 없이도 정렬 + 동시성을 동시에 만족.

# ✨개선 사항 및 참고 사항
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 


# 💯 테스트
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 

# 확인
- [ ] 주석 및 print를 제거하셨나요?
- [ ] javaDoc을 작성하셨나요?
- [ ] merge할 브랜치와 로컬에서 merge 하셨나요?
- [ ] 더 수정할 작업은 없는지 확인하셨나요?
