### PR TITLE
feat(user): 유저 프로필 응답에 팔로우 상태 추가

### DIFF
--- a/src/main/java/core/domain/user/dto/UserProfileCardResponse.java
+++ b/src/main/java/core/domain/user/dto/UserProfileCardResponse.java
@@ -1,0 +1,42 @@
+package core.domain.user.dto;
+
+import core.domain.user.entity.User;
+
+import java.util.List;
+
+
+import core.domain.user.entity.User;
+import java.util.List;
+
+public record UserProfileCardResponse(
+        Long userId,
+        String firstname,
+        String lastname,
+        String gender,
+        String birthday,
+        String country,
+        String introduction,
+        String purpose,
+        List<String> language,
+        List<String> hobby,
+        String imageKey,
+        String followStatus
+) {
+
+    public UserProfileCardResponse(User u, List<String> languages, List<String> hobbies, String imageKey, String followStatus) {
+        this(
+                u.getId(),
+                u.getFirstName(),
+                u.getLastName(),
+                u.getSex(),
+                u.getBirthdate(),
+                u.getCountry(),
+                u.getIntroduction(),
+                u.getPurpose(),
+                languages,
+                hobbies,
+                imageKey,
+                followStatus // 👈 추가
+        );
+    }
+}

--- a/src/main/java/core/domain/user/repository/FollowRepository.java
+++ b/src/main/java/core/domain/user/repository/FollowRepository.java
@@ -83,4 +83,6 @@ public interface FollowRepository extends JpaRepository<Follow,Long> {
     @Query("SELECT f.following.id FROM Follow f " +
             "WHERE f.user.id = :userId AND f.status IN :statuses")
     Set<Long> findFollowingIdsByUserId(@Param("userId") Long userId, @Param("statuses") List<FollowStatus> statuses);
+
+    Optional<Follow> findByUser_IdAndFollowing_Id(Long userId, Long followingId);
 }

--- a/src/main/java/core/domain/user/service/UserService.java
+++ b/src/main/java/core/domain/user/service/UserService.java
@@ -15,6 +15,7 @@ import core.domain.post.entity.Post;
 import core.domain.post.repository.BlockPostRepository;
 import core.domain.post.repository.PostRepository;
 import core.domain.user.dto.*;
+import core.domain.user.entity.Follow;
 import core.domain.user.entity.User;
 import core.domain.user.repository.BlockRepository;
 import core.domain.user.repository.FollowRepository;
@@ -785,7 +786,31 @@ public class UserService {
 
         return new UserProfileResponse(user, stringToList(user.getTranslateLanguage()), stringToList(user.getHobby()), profileKey);
     }
+    public UserProfileCardResponse findCardUserProfile(Long userId, Long currentUserId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
+        String profileKey = imageService.getUserProfileKey(user.getId());
+        String followStatus;
+        if (userId.equals(currentUserId)) {
+            followStatus = "SELF";
+        } else {
+            Optional<Follow> follow = followRepository.findByUser_IdAndFollowing_Id(currentUserId, userId);
+            if (follow.isPresent()) {
+                followStatus = follow.get().getStatus().toString();
+            } else {
+                followStatus = "NOT_FOLLOWING";
+            }
+        }
+
+        return new UserProfileCardResponse(
+                user,
+                stringToList(user.getTranslateLanguage()),
+                stringToList(user.getHobby()),
+                profileKey,
+                followStatus
+        );
+    }
     /**
      * 여러 사용자 정보 일괄 조회 로직 (N+1 문제 해결)
      */

--- a/src/main/java/core/global/controller/UserController.java
+++ b/src/main/java/core/global/controller/UserController.java
@@ -24,6 +24,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
@@ -135,7 +136,16 @@ public class UserController {
             return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
-
+    @GetMapping("/{userId}/info")
+    public ResponseEntity<UserProfileCardResponse> getUserProfile(
+            @PathVariable("userId") Long userId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long currentUserId = userDetails.getUserId();
+        UserProfileCardResponse userProfile = userService.findCardUserProfile(userId, currentUserId);
+        featureUsageMetrics.recordFollowUsage();
+        return ResponseEntity.ok(userProfile);
+    }
 
 
 


### PR DESCRIPTION
PR 변경사항
기존 유저 프로필 조회 API 응답(UserProfileResponse)에 현재 로그인한 유저와 대상 유저 간의 팔로우 상태(followStatus)를 추가했습니다.

🖌️ 구체적인 구현 내용
UserController: Authentication 객체를 통해 현재 로그인한 유저의 ID를 UserService로 전달합니다.

UserService:

본인 프로필 조회 시 SELF를 반환합니다.

FollowRepository를 조회하여 두 유저 간의 관계를 확인하고, ACCEPTED, PENDING, NOT_FOLLOWING 상태를 결정합니다.

UserProfileResponse (DTO): followStatus (String) 필드를 추가했습니다.

FollowRepository: findByUser_IdAndFollowing_Id 메서드를 추가하여 특정 팔로우 관계를 조회합니다.

✨개선 사항 및 참고 사항
이제 클라이언트에서 유저 프로필을 볼 때, 팔로우 상태를 확인하기 위한 별도의 API 호출 없이 '팔로우', '팔로잉', '요청 보냄' 등 버튼 UI를 즉시 표시할 수 있습니다.

💯 테스트
Postman을 통해 각 시나리오별로 followStatus가 올바르게 반환되는지 확인했습니다.

본인 프로필 조회 시: "SELF"

팔로우하지 않는 유저 조회 시: "NOT_FOLLOWING"

이미 팔로우(수락)한 유저 조회 시: "ACCEPTED"

팔로우 요청만 보낸 유저 조회 시: "PENDING"

확인
[x] 주석 및 print를 제거하셨나요?

[ ] javaDoc을 작성하셨나요?

[x] merge할 브랜치와 로컬에서 merge 하셨나요?

[x] 더 수정할 작업은 없는지 확인하셨나요?