### PR TITLE
채팅방 알림 판별 & 알림 데이터 전송 작업 

### DIFF
--- a/src/main/java/core/domain/chat/controller/ChatController.java
+++ b/src/main/java/core/domain/chat/controller/ChatController.java
@@ -401,7 +401,7 @@ public class ChatController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "알림 설정 변경 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "채팅방 또는 해당 채팅방의 참여자가 아닐 경우")
     })
-    @PostMapping("/rooms/{roomId}/notifications")
+    @PostMapping("/rooms/{roomId}/notifications-toggle")
     public ResponseEntity<ApiResponse<Void>> toggleChatRoomNotifications(
             @Parameter(description = "설정을 변경할 채팅방의 ID") @PathVariable Long roomId,
             @Valid @RequestBody ToggleNotificationsRequest request,@AuthenticationPrincipal CustomUserDetails principal
@@ -411,4 +411,22 @@ public class ChatController {
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 
+
+    @Operation(summary = "채팅방 알림 상태 조회", description = "현재 유저의 특정 채팅방 알림 설정 상태(on/off)를 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공",
+                    content = @Content(schema = @Schema(implementation = ChatNotificationStatusResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 채팅방 또는 참여자가 아님",
+                    content = @Content(schema = @Schema(implementation = Object.class))
+            )
+    })
+    @GetMapping("/rooms/{roomId}/notification-status")
+    public ResponseEntity<ApiResponse<ChatNotificationStatusResponse>> getNotificationStatus(
+            @Parameter(description = "채팅방 ID") @PathVariable @Positive Long roomId,@AuthenticationPrincipal CustomUserDetails principal
+    ) {
+        Long userId = principal.getUserId();
+        ChatNotificationStatusResponse response= chatService.isNotificationsEnabled(roomId, userId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
 }

--- a/src/main/java/core/domain/chat/controller/ChatController.java
+++ b/src/main/java/core/domain/chat/controller/ChatController.java
@@ -100,7 +100,7 @@ public class ChatController {
             @PathVariable Long roomId,
             @RequestParam(required = false) Long lastMessageId,
             @AuthenticationPrincipal CustomUserDetails principal
-    ) {;
+    ) {
         Long userId = principal.getUserId();
 
         List<ChatMessageResponse> responses = chatService.getMessages(roomId, userId, lastMessageId);
@@ -137,8 +137,7 @@ public class ChatController {
             )
     })
     @GetMapping("/rooms/{roomId}/participants")
-    public ResponseEntity<ApiResponse<List<ChatRoomParticipantsResponse>>> getParticipants(@PathVariable Long roomId,
-                                                                                           @AuthenticationPrincipal CustomUserDetails principal) {
+    public ResponseEntity<ApiResponse<List<ChatRoomParticipantsResponse>>> getParticipants(@PathVariable Long roomId){
         List<ChatRoomParticipantsResponse> responses = chatService.getRoomParticipants(roomId);
         featureUsageMetrics.recordChatUsage();
         return ResponseEntity.ok(ApiResponse.success(responses));

--- a/src/main/java/core/domain/chat/controller/ChatController.java
+++ b/src/main/java/core/domain/chat/controller/ChatController.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
@@ -45,9 +46,8 @@ public class ChatController {
     })
     @PostMapping("/rooms/oneTone")
     public ResponseEntity<ApiResponse<ChatRoomResponse>> createRoom(
-            @RequestBody CreateRoomRequest request
+            @RequestBody CreateRoomRequest request,@AuthenticationPrincipal CustomUserDetails principal
     ) {
-        CustomUserDetails principal = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         Long userId = principal.getUserId();
         ChatRoom room = chatService.createRoom(userId, request.otherUserId());
         ChatRoomResponse response = ChatRoomResponse.from(room);
@@ -62,8 +62,7 @@ public class ChatController {
             )
     })
     @GetMapping("/rooms")
-    public ResponseEntity<ApiResponse<List<ChatRoomSummaryResponse>>> ChatRooms() {
-        CustomUserDetails principal = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    public ResponseEntity<ApiResponse<List<ChatRoomSummaryResponse>>> ChatRooms(@AuthenticationPrincipal CustomUserDetails principal) {
         Long userId = principal.getUserId();
         List<ChatRoomSummaryResponse> responses = chatService.getMyAllChatRoomSummaries(userId);
         ResponseEntity<ApiResponse<List<ChatRoomSummaryResponse>>> responseEntity =
@@ -79,8 +78,7 @@ public class ChatController {
             )
     })
     @DeleteMapping("/rooms/{roomId}/leave")
-    public ResponseEntity<ApiResponse<Void>> leaveChatRoom(@PathVariable Long roomId) {
-        CustomUserDetails principal = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    public ResponseEntity<ApiResponse<Void>> leaveChatRoom(@PathVariable Long roomId,@AuthenticationPrincipal CustomUserDetails principal) {
         Long userId = principal.getUserId();
         chatService.leaveRoom(roomId, userId);
         featureUsageMetrics.recordChatUsage();
@@ -100,10 +98,9 @@ public class ChatController {
     @GetMapping("/rooms/{roomId}/messages")
     public ResponseEntity<ApiResponse<List<ChatMessageResponse>>> getMessages(
             @PathVariable Long roomId,
-            @RequestParam(required = false) Long lastMessageId
-    ) {
-        log.info("lastMessageId: 이거입니다!: {}",lastMessageId);
-        CustomUserDetails principal = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+            @RequestParam(required = false) Long lastMessageId,
+            @AuthenticationPrincipal CustomUserDetails principal
+    ) {;
         Long userId = principal.getUserId();
 
         List<ChatMessageResponse> responses = chatService.getMessages(roomId, userId, lastMessageId);
@@ -121,9 +118,9 @@ public class ChatController {
     })
     @GetMapping("/rooms/{roomId}/first_messages")
     public ResponseEntity<ApiResponse<List<ChatMessageFirstResponse>>> getFirstMessages(
-            @PathVariable Long roomId
+            @PathVariable Long roomId,
+            @AuthenticationPrincipal CustomUserDetails principal
     ) {
-        CustomUserDetails principal = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         Long userId = principal.getUserId();
         List<ChatMessageFirstResponse> responses = chatService.getFirstMessages(roomId, userId);
         featureUsageMetrics.recordChatUsage();
@@ -140,7 +137,8 @@ public class ChatController {
             )
     })
     @GetMapping("/rooms/{roomId}/participants")
-    public ResponseEntity<ApiResponse<List<ChatRoomParticipantsResponse>>> getParticipants(@PathVariable Long roomId) {
+    public ResponseEntity<ApiResponse<List<ChatRoomParticipantsResponse>>> getParticipants(@PathVariable Long roomId,
+                                                                                           @AuthenticationPrincipal CustomUserDetails principal) {
         List<ChatRoomParticipantsResponse> responses = chatService.getRoomParticipants(roomId);
         featureUsageMetrics.recordChatUsage();
         return ResponseEntity.ok(ApiResponse.success(responses));
@@ -155,10 +153,9 @@ public class ChatController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 채팅방 또는 유저")
     })
     @PostMapping("/rooms/group/{roomId}/join")
-    public ResponseEntity<ApiResponse<Void>> joinGroupChat(@PathVariable Long roomId) {
-        CustomUserDetails principal = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    public ResponseEntity<ApiResponse<Void>> joinGroupChat(@PathVariable Long roomId,
+                                                           @AuthenticationPrincipal CustomUserDetails principal) {
         Long userId = principal.getUserId();
-
         chatService.joinGroupChat(roomId, userId);
         featureUsageMetrics.recordChatUsage();
         return ResponseEntity.ok(ApiResponse.success(null));
@@ -180,9 +177,9 @@ public class ChatController {
     
     public ResponseEntity<ApiResponse<List<ChatMessageResponse>>> searchMessages(
             @RequestParam Long roomId,
-            @RequestParam String keyword
+            @RequestParam String keyword,
+            @AuthenticationPrincipal CustomUserDetails principal
     ) {
-        CustomUserDetails principal = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         Long userId = principal.getUserId();
 
         List<ChatMessageResponse> responses = chatService.searchMessages(roomId, userId, keyword);
@@ -205,9 +202,9 @@ public class ChatController {
     
     public ResponseEntity<ApiResponse<List<ChatMessageResponse>>> getMessagesAround(
             @PathVariable Long roomId,
-            @RequestParam Long messageId
+            @RequestParam Long messageId,
+            @AuthenticationPrincipal CustomUserDetails principal
     ) {
-        CustomUserDetails principal = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         Long userId = principal.getUserId();
 
         List<ChatMessageResponse> responses = chatService.getMessagesAround(roomId, userId, messageId);
@@ -242,9 +239,8 @@ public class ChatController {
     @GetMapping("/rooms/search")
     
     public ResponseEntity<ApiResponse<List<ChatRoomSummaryResponse>>> searchRooms(
-            @RequestParam("roomName") String roomName
+            @RequestParam("roomName") String roomName,@AuthenticationPrincipal CustomUserDetails principal
     ) {
-        CustomUserDetails principal = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         List<ChatRoomSummaryResponse> responses = chatService.searchRoomsByRoomName(principal.getUserId(), roomName);
         featureUsageMetrics.recordChatUsage();
         return ResponseEntity.ok(ApiResponse.success(responses));
@@ -320,8 +316,8 @@ public class ChatController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "채팅방을 찾을 수 없음")
     })
     @PostMapping("/rooms/{roomId}/read-all")
-    public ResponseEntity<ApiResponse<Void>> markAllAsRead(@PathVariable Long roomId) {
-        CustomUserDetails principal = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    public ResponseEntity<ApiResponse<Void>> markAllAsRead(@PathVariable Long roomId,
+                                                           @AuthenticationPrincipal CustomUserDetails principal) {
         Long userId = principal.getUserId();
         chatService.markAllMessagesAsReadInRoom(roomId, userId);
         return ResponseEntity.ok(ApiResponse.success(null));
@@ -334,9 +330,9 @@ public class ChatController {
     })
     @PostMapping("/rooms/group")
     public ResponseEntity<ApiResponse<Void>> createGroupChat(
-                                                              @Valid @RequestBody CreateGroupChatRequest request
+                                                              @Valid @RequestBody CreateGroupChatRequest request,
+                                                              @AuthenticationPrincipal CustomUserDetails principal
     ) {
-        CustomUserDetails principal = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         Long userId = principal.getUserId();
         chatService.createGroupChatRoom(userId, request);
         featureUsageMetrics.recordChatUsage();
@@ -346,11 +342,13 @@ public class ChatController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK 응답 반환")
     })
+
     @PostMapping("/declaration")
     public ResponseEntity<ApiResponse<Void>> okOnly(@RequestBody String ignored) {
         featureUsageMetrics.recordChatUsage();
         return ResponseEntity.ok(ApiResponse.success(null));
     }
+
     @Operation(summary = "채팅방이 그룹인지 여부 확인", description = "roomId에 해당하는 채팅방이 그룹 채팅방인지(1:1 채팅인지) 확인합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = ChatRoomGroupResponse.class))),
@@ -379,7 +377,7 @@ public class ChatController {
                 .status(HttpStatus.CREATED)
                 .body(core.global.dto.ApiResponse.success("차단 성공"));
     }
-    @Operation(summary = "채팅 미디어 Presigned URL 발급", // ✅ API 제목
+    @Operation(summary = "채팅 미디어 Presigned URL 발급",
             description = """
                지정된 채팅방(chatroomId)에 사진이나 동영상을 업로드할 수 있는, 15분간 유효한 일회성 URL을 발급합니다.
                
@@ -407,13 +405,10 @@ public class ChatController {
     @PostMapping("/rooms/{roomId}/notifications")
     public ResponseEntity<ApiResponse<Void>> toggleChatRoomNotifications(
             @Parameter(description = "설정을 변경할 채팅방의 ID") @PathVariable Long roomId,
-            @Valid @RequestBody ToggleNotificationsRequest request
+            @Valid @RequestBody ToggleNotificationsRequest request,@AuthenticationPrincipal CustomUserDetails principal
     ) {
-        CustomUserDetails principal = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         Long userId = principal.getUserId();
-
         chatService.toggleChatRoomNotifications(roomId, userId, request.enabled());
-
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 

--- a/src/main/java/core/domain/chat/dto/ChatNotificationStatusResponse.java
+++ b/src/main/java/core/domain/chat/dto/ChatNotificationStatusResponse.java
@@ -1,0 +1,9 @@
+package core.domain.chat.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "채팅방 알림 상태 응답 DTO")
+public record ChatNotificationStatusResponse(
+        @Schema(description = "알림 활성화 여부 (true: 켱, false: 끔)")
+        boolean enabled
+) { }

--- a/src/main/java/core/domain/chat/service/ChatService.java
+++ b/src/main/java/core/domain/chat/service/ChatService.java
@@ -80,7 +80,6 @@ public class ChatService {
         List<ChatRoom> rooms = chatRoomRepo.findActiveHumanChatRoomsByUserId(userId, ChatParticipantStatus.ACTIVE);
 
         return rooms.stream()
-                // 🚨 차단 필터링 로직
                 .filter(room -> {
                     if (room.getGroup()) {
                         return true;
@@ -96,7 +95,7 @@ public class ChatService {
 
                         boolean isBlockedByMe = blockRepository.existsBlock(userId, opponentId);
 
-                        return !isBlockedByMe; // '내가 차단한 경우만 숨김'이 일반적
+                        return !isBlockedByMe;
                     }
 
                     return true;
@@ -110,7 +109,6 @@ public class ChatService {
                     ChatRoom room = roomWithTime.room();
                     Instant lastMessageTime = roomWithTime.lastMessageTime();
 
-                    // 그룹 채팅방의 마지막 메시지는 차단된 유저 메시지를 제외
                     String lastMessageContent = getLastNonBlockedMessageContent(room.getId(), userId);
                     int unreadCount = countUnreadMessages(room.getId(), userId);
                     int participantCount = room.getParticipants().size();
@@ -229,8 +227,6 @@ public class ChatService {
                 countryOf(otherUser),
                 "chat_room"
         );
-
-
         return chatRoomRepo.save(newRoom);
     }
 
@@ -963,7 +959,8 @@ public class ChatService {
                         senderUser.getId(),
                         NotificationType.chat,
                         chatRoom.getId(),
-                        originalContent
+                        originalContent,
+                        chatRoom.getRoomName()
                 );
                 eventPublisher.publishEvent(event);
             }

--- a/src/main/java/core/domain/chat/service/ChatService.java
+++ b/src/main/java/core/domain/chat/service/ChatService.java
@@ -1,6 +1,7 @@
 package core.domain.chat.service;
 
 
+import com.google.api.gax.rpc.NotFoundException;
 import core.domain.chat.dto.*;
 import core.domain.chat.entity.ChatMessage;
 import core.domain.chat.entity.ChatParticipant;
@@ -1313,5 +1314,11 @@ public class ChatService {
         ChatParticipant participant = participantOptional.get();
         participant.setNotificationsEnabled(enabled);
 
+    }
+    public ChatNotificationStatusResponse isNotificationsEnabled(Long roomId, Long userId) {
+         ChatParticipant participant =
+                 chatParticipantRepository.findByChatRoomIdAndUserId(roomId, userId)
+                         .orElseThrow(() -> new BusinessException(ErrorCode.CHAT_PARTICIPANT_NOT_FOUND));
+        return new ChatNotificationStatusResponse(participant.isNotificationsEnabled());
     }
 }

--- a/src/main/java/core/domain/chat/service/ChatService.java
+++ b/src/main/java/core/domain/chat/service/ChatService.java
@@ -1,7 +1,4 @@
 package core.domain.chat.service;
-
-
-import com.google.api.gax.rpc.NotFoundException;
 import core.domain.chat.dto.*;
 import core.domain.chat.entity.ChatMessage;
 import core.domain.chat.entity.ChatParticipant;
@@ -129,7 +126,7 @@ public class ChatService {
                                     .map(Image::getUrl)
                                     .orElse(null);
                         } else {
-                            roomName = "(알 수 없는 사용자)";
+                            roomName = "Unknown user";
                             roomImageUrl = null;
                         }
 
@@ -616,7 +613,7 @@ public class ChatService {
                     .orElse(null);
 
             if (opponent == null) {
-                roomName = "(알 수 없음)";
+                roomName = "Unknown user";
                 roomImageUrl = null;
             } else {
                 roomName = opponent. getFirstName() + " " + opponent.getLastName();
@@ -666,10 +663,6 @@ public class ChatService {
                 .orElse(null);
     }
 
-    public ChatRoom getChatRoomById(Long roomId) {
-        return chatRoomRepository.findByIdWithParticipantsAndUsers(roomId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.CHAT_ROOM_NOT_FOUND));
-    }
     @Transactional(readOnly = true)
     public GroupChatDetailResponse getGroupChatDetails(Long chatRoomId) {
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
@@ -715,8 +708,6 @@ public class ChatService {
      */
     @Transactional
     public void joinGroupChat(Long roomId, Long userId) {
-        String email = SecurityContextHolder.getContext().getAuthentication().getName();
-
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
@@ -915,7 +906,7 @@ public class ChatService {
 
     @Transactional
     public void processAndSendChatMessage(SendMessageRequest req) {
-        Long startTime = System.currentTimeMillis();
+        long startTime = System.currentTimeMillis();
         ChatMessage savedMessage = this.saveMessage(req.roomId(), req.senderId(), req.content());
         String originalContent = savedMessage.getContent();
 

--- a/src/main/java/core/domain/comment/service/impl/CommentServiceImpl.java
+++ b/src/main/java/core/domain/comment/service/impl/CommentServiceImpl.java
@@ -130,7 +130,8 @@ public class CommentServiceImpl implements CommentService {
                             NotificationType.post,
                             post.getId(),
                             savedComment.getId(), // ✅ 2. 저장된 댓글의 ID를 이벤트에 추가
-                            request.comment()
+                            request.comment(),
+                            null
                     );
                     eventPublisher.publishEvent(event);
                 }
@@ -143,7 +144,8 @@ public class CommentServiceImpl implements CommentService {
                             NotificationType.comment,
                             post.getId(),
                             savedComment.getId(), // ✅ 2. 저장된 답글의 ID를 이벤트에 추가
-                            request.comment()
+                            request.comment(),
+                            null
                     );
                     eventPublisher.publishEvent(event);
                 }

--- a/src/main/java/core/domain/notification/dto/NotificationEvent.java
+++ b/src/main/java/core/domain/notification/dto/NotificationEvent.java
@@ -19,9 +19,13 @@ public record NotificationEvent(
         NotificationType notificationType,
         Long referenceId,
         Long commentId,
-        String contentSnippet
+        String contentSnippet,
+        String roomName
 ) {
     public NotificationEvent(Long recipientId, Long actorId, NotificationType notificationType, Long referenceId, String contentSnippet) {
-        this(recipientId, actorId, notificationType, referenceId, null, contentSnippet);
+        this(recipientId, actorId, notificationType, referenceId, null, contentSnippet,null);
+    }
+    public NotificationEvent(Long recipientId, Long actorId, NotificationType notificationType, Long referenceId, String contentSnippet,String roomName) {
+        this(recipientId, actorId, notificationType, referenceId, null, contentSnippet,roomName);
     }
 }

--- a/src/main/java/core/domain/notification/entity/Notification.java
+++ b/src/main/java/core/domain/notification/entity/Notification.java
@@ -50,6 +50,9 @@ public class Notification {
     @Column(name = "sub_reference_id")
     private Long subReferenceId;
 
+    @Column(name = "context_info", length = 255)
+    private String contextInfo;
+
     @Builder
     public Notification(User user,
                         String message,

--- a/src/main/java/core/domain/notification/service/NotificationMessageGenerator.java
+++ b/src/main/java/core/domain/notification/service/NotificationMessageGenerator.java
@@ -26,7 +26,7 @@ public class NotificationMessageGenerator {
                 if (snippet != null && snippet.length() > 30) {
                     snippet = snippet.substring(0, 30) + "...";
                 }
-                yield actorName + "님으로부터 새로운 메시지: " + snippet;
+                yield actorName + "A new message from you: " + snippet;
             }
 
             case post -> actorName + " commented on your post.";

--- a/src/main/java/core/domain/notification/service/PushNotificationService.java
+++ b/src/main/java/core/domain/notification/service/PushNotificationService.java
@@ -104,10 +104,17 @@ public class PushNotificationService {
                             .putData("followerId", String.valueOf(event.actorId()));
                     break;
                 case chat:
+                    String roomName = event.roomName();
+                    if (roomName == null) {
+                        roomName = "Unknown Chat Room";
+                        log.warn("Chat notification event is missing roomName. ChatRoom ID: {}. Using default value '{}'.", event.referenceId(), roomName);
+                    }
+
                     messageBuilder
                             .putData("type", "chat")
                             .putData("roomId", String.valueOf(event.referenceId()))
-                            .putData("myId", String.valueOf(recipient.getId()));
+                            .putData("myId", String.valueOf(recipient.getId()))
+                            .putData("roomName", roomName);
                     break;
                 case newuser:
                     messageBuilder

--- a/src/main/java/core/domain/post/service/impl/PostServiceImpl.java
+++ b/src/main/java/core/domain/post/service/impl/PostServiceImpl.java
@@ -248,7 +248,6 @@ public class PostServiceImpl implements PostService {
                     author.getId(),
                     NotificationType.followuserpost,
                     post.getId(),
-                    null,
                     null
             );
             eventPublisher.publishEvent(event);

--- a/src/main/java/core/domain/user/entity/User.java
+++ b/src/main/java/core/domain/user/entity/User.java
@@ -114,7 +114,8 @@ public class User {
                 String hobby,
                 String provider,
                 String socialId,
-                String email,String appleRefreshToken) {
+                String email,String appleRefreshToken
+                ,Instant createdAt) {
         this.firstName = firstName;
         this.lastName = lastName;
         this.sex = sex;
@@ -128,6 +129,7 @@ public class User {
         this.socialId = socialId;
         this.email = email;
         this.appleRefreshToken = appleRefreshToken;
+        this.createdAt = createdAt;
     }
     public void updateFirstName(String firstName) {
         if (notBlank(firstName)) this.firstName = firstName.trim();

--- a/src/main/java/core/domain/user/service/UserService.java
+++ b/src/main/java/core/domain/user/service/UserService.java
@@ -357,7 +357,7 @@ public class UserService {
         redisService.saveRefreshToken(u.getId(), refreshToken, expirationMillis);
 
         publisher.publishEvent(new UserLoggedInEvent(u.getId().toString(), "local"));
-
+        publisher.publishEvent(new NewUserJoinedEvent(u.getId()));
         return new LoginResponseDto(u.getId(), accessToken, refreshToken, u.isNewUser());
     }
 

--- a/src/main/java/core/domain/user/service/UserService.java
+++ b/src/main/java/core/domain/user/service/UserService.java
@@ -123,8 +123,8 @@ public class UserService {
                 .socialId(socialId)
                 .email(email)
                 .provider(provider)
+                .createdAt(Instant.now())
                 .build();
-
         return userRepository.save(u);
     }
 
@@ -138,6 +138,7 @@ public class UserService {
                 .appleRefreshToken(appleRefreshToken)
                 .firstName(name.familyName())
                 .lastName(name.givenName())
+                .createdAt(Instant.now())
                 .build();
 
         return userRepository.save(u);

--- a/src/main/java/core/global/service/GoogleAuthService.java
+++ b/src/main/java/core/global/service/GoogleAuthService.java
@@ -35,7 +35,6 @@ public class GoogleAuthService {
         AccessTokenDto accessTokenDto = googleService.exchangeCode(authCode);
 
         GoogleProfileDto profile = googleService.getGoogleProfile(accessTokenDto.getAccess_token());
-
         User user = findOrCreateUser(profile);
 
         String accessToken = jwtTokenProvider.createAccessToken(user.getId(), user.getEmail());
@@ -45,7 +44,8 @@ public class GoogleAuthService {
         long expirationMillis = expirationDate.getTime() - System.currentTimeMillis();
         redisService.saveRefreshToken(user.getId(), refreshToken, expirationMillis);
 
-        boolean isNewUserResponse = user.isNewUser();if (isNewUserResponse) {
+        boolean isNewUserResponse = user.isNewUser();
+        if (isNewUserResponse) {
             publisher.publishEvent(new NewUserJoinedEvent(user.getId()));
         }
 

--- a/src/main/java/core/global/service/GoogleAuthService.java
+++ b/src/main/java/core/global/service/GoogleAuthService.java
@@ -1,6 +1,7 @@
 package core.global.service;
 
 
+import core.domain.notification.dto.NewUserJoinedEvent;
 import core.domain.user.entity.User;
 import core.domain.user.service.UserService;
 import core.global.config.JwtTokenProvider;
@@ -44,7 +45,9 @@ public class GoogleAuthService {
         long expirationMillis = expirationDate.getTime() - System.currentTimeMillis();
         redisService.saveRefreshToken(user.getId(), refreshToken, expirationMillis);
 
-        boolean isNewUserResponse = user.isNewUser();
+        boolean isNewUserResponse = user.isNewUser();if (isNewUserResponse) {
+            publisher.publishEvent(new NewUserJoinedEvent(user.getId()));
+        }
 
         publisher.publishEvent(new UserLoggedInEvent(user.getId().toString(), "google"));
 

--- a/src/main/resources/db/migration/V202051104_01__add_context_info_to_notification.sql
+++ b/src/main/resources/db/migration/V202051104_01__add_context_info_to_notification.sql
@@ -1,0 +1,2 @@
+ALTER TABLE notification
+    ADD COLUMN context_info VARCHAR(255);


### PR DESCRIPTION
# 📄 PR 변경사항
- 채팅방 알림 판별 & 알림 데이터 전송 작업

# 🖌️ 구체적인 구현 내용
- 채팅방별 알람 on/off api 구현
- 채팅방별 알람 상태 get api 구현
- 채팅 ,그룹채팅 알람 데이터에 roomName 데이터 추가
- 신규유저 가입시 간헐적으로만 알람오는 문제 해결
- chat 컨트롤러 userId 뽑는 방식 @AuthenticationPrincipal CustomUserDetails principal으로 변경
- 

# ✨개선 사항 및 참고 사항
알람은 운영환경에서 테스트 필요
#211 
# 💯 테스트
- 플라이웨이 스키마 변경 잘되는것 확인  

# 확인
- [x] 주석 및 print를 제거하셨나요?
- [ ] javaDoc을 작성하셨나요?
- [x] merge할 브랜치와 로컬에서 merge 하셨나요?
- [x] 더 수정할 작업은 없는지 확인하셨나요?
