### PR TITLE
Refator#225 bug websocket 메시지 전송 시 customuserdetails 관련 messageconversionexception 발생

### DIFF
--- a/src/main/java/core/global/metrics/SocialChatMetrics.java
+++ b/src/main/java/core/global/metrics/SocialChatMetrics.java
@@ -25,7 +25,6 @@ public class SocialChatMetrics {
     private final AtomicInteger activeChatRooms = new AtomicInteger(0);
     private final AtomicInteger totalChatRooms = new AtomicInteger(0);
     private final AtomicInteger activeFollowEdges = new AtomicInteger(0);
-    // 선택: 활성 방 추적을 위해 방별 상태 관리
     private final ConcurrentHashMap<String, Boolean> roomActiveMap = new ConcurrentHashMap<>();
 
     public SocialChatMetrics(MeterRegistry registry) {

--- a/src/main/java/core/global/websocket/config/StompChannelInterceptor.java
+++ b/src/main/java/core/global/websocket/config/StompChannelInterceptor.java
@@ -18,7 +18,8 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
-
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.ArrayList;
 import java.util.Map;
 
@@ -31,7 +32,7 @@ public class StompChannelInterceptor implements ChannelInterceptor {
     private final RedisService redisService;
     private final UserActivityService userActivityService;
     private final ChatRoomDwellRecorder dwell;
-
+    private static final Pattern ROOM_ID_PATTERN = Pattern.compile("^/topic/chatrooms/([a-zA-Z0-9_-]+)$");
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);

--- a/src/main/java/core/global/websocket/config/StompChannelInterceptor.java
+++ b/src/main/java/core/global/websocket/config/StompChannelInterceptor.java
@@ -90,7 +90,6 @@ public class StompChannelInterceptor implements ChannelInterceptor {
 
         } else if (StompCommand.DISCONNECT.equals(accessor.getCommand())) {
 
-            // 채팅 체류 종료
             Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
             if (sessionAttributes != null) {
                 Long userId = (Long) sessionAttributes.get("userId");
@@ -108,10 +107,8 @@ public class StompChannelInterceptor implements ChannelInterceptor {
         return message;
     }
 
-    // 유틸: roomId만 뽑기 (컨트롤러가 사용 중인 topic 경로에 맞춤)
     private String parseRoomId(String dest) {
         if (dest == null) return "unknown";
-        // 예) /topic/chatrooms/{roomId}
         String[] parts = dest.split("/");
         return parts.length > 0 ? parts[parts.length - 1] : "unknown";
     }

--- a/src/main/java/core/global/websocket/config/StompChannelInterceptor.java
+++ b/src/main/java/core/global/websocket/config/StompChannelInterceptor.java
@@ -71,8 +71,7 @@ public class StompChannelInterceptor implements ChannelInterceptor {
                     String userEmail = auth.getName();
                     userActivityService.updateLastSeenAt(userEmail);
                 }
-
-                // 필요 시 accessor.setUser(auth) 유지
+                accessor.setUser(auth);
                 log.info("STOMP JWT 인증 완료: WebSocket 세션에 사용자 정보 등록 (userId: {})", userId);
 
             } catch (Exception e) {
@@ -82,25 +81,11 @@ public class StompChannelInterceptor implements ChannelInterceptor {
 
         } else if (StompCommand.SEND.equals(accessor.getCommand()) || StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
 
-            Authentication auth = null;
-            Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
-            if (sessionAttributes != null) {
-                auth = (Authentication) sessionAttributes.get("userAuth");
-            }
-
             if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
                 String sessionId = accessor.getSessionId();
-                String dest = accessor.getDestination(); // 예: /topic/chatrooms/{roomId}
+                String dest = accessor.getDestination();
                 String roomId = parseRoomId(dest);
                 dwell.onEnter(sessionId, roomId);
-            }
-
-            if (auth != null) {
-                SecurityContextHolder.getContext().setAuthentication(auth);
-                log.debug("STOMP AUTHORIZED: SecurityContextHolder에 인증 정보 설정 완료, command={}", accessor.getCommand());
-            } else {
-                log.warn("STOMP UNAUTHORIZED: WebSocket 세션에 인증 정보가 없습니다, command={}", accessor.getCommand());
-                return null; // 인증 없으면 차단
             }
 
         } else if (StompCommand.DISCONNECT.equals(accessor.getCommand())) {

--- a/src/main/java/core/global/websocket/config/StompChannelInterceptor.java
+++ b/src/main/java/core/global/websocket/config/StompChannelInterceptor.java
@@ -32,7 +32,6 @@ public class StompChannelInterceptor implements ChannelInterceptor {
     private final RedisService redisService;
     private final UserActivityService userActivityService;
     private final ChatRoomDwellRecorder dwell;
-    private static final Pattern ROOM_ID_PATTERN = Pattern.compile("^/topic/chatrooms/([a-zA-Z0-9_-]+)$");
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);

--- a/src/main/java/core/global/websocket/config/WebSocketConfig.java
+++ b/src/main/java/core/global/websocket/config/WebSocketConfig.java
@@ -62,8 +62,6 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer,
     @Override
     public void configureClientInboundChannel(ChannelRegistration registration) {
         registration.interceptors(stompChannelInterceptor);
-
-        // 5. @Bean 메소드를 직접 호출하는 대신, 생성자에서 주입받은 필드를 사용합니다.
         registration.interceptors(this.securityContextChannelInterceptor);
     }
 


### PR DESCRIPTION
📄 PR 변경사항
웹소켓 메시지 전송(@MessageMapping) 시, @AuthenticationPrincipal이 올바른 유저 정보를 주입받지 못하고 userId: -1로 설정되는 문제를 해결했습니다.


🖌️ 구체적인 구현 내용
웹소켓 인증 처리 과정에서 커스텀 인터셉터와 Spring Security의 기본 인터셉터 간의 충돌이 발생했습니다.

[문제 원인]
CONNECT (기존): 커스텀 StompChannelInterceptor가 sessionAttributes에만 인증 정보를 저장하고, Spring Security가 인지하는 accessor.setUser(auth)를 호출하지 않았습니다.
SEND (기존): StompChannelInterceptor가 SecurityContextHolder를 수동으로 설정(A)했습니다.
SEND (충돌): 하지만 이후 실행된 SecurityContextChannelInterceptor는 accessor.getUser()가 null이므로, SecurityContext를 익명 사용자(Anonymous)로 덮어썼습니다(B).
Controller (결과): @AuthenticationPrincipal이 Anonymous를 CustomUserDetails로 변환하려다 기본 생성자(userId: -1)를 호출하여 오류가 발생했습니다.

[구현 내용]

StompChannelInterceptor (CONNECT 시):
JWT 토큰 검증 후 Authentication 객체가 생성되면, sessionAttributes 저장과 더불어 **accessor.setUser(auth)**를 호출하도록 추가했습니다.
이를 통해 Spring Security가 해당 웹소켓 세션의 인증 정보를 공식적으로 인지하게 합니다.
StompChannelInterceptor (SEND / SUBSCRIBE 시):
SecurityContextHolder를 수동으로 조작하던 로직을 모두 제거했습니다.
SecurityContext 관리를 SecurityContextChannelInterceptor에 위임하여 충돌을 원천적으로 제거했습니다.

✨개선 사항 및 참고 사항

💯 테스트

확인
[x] 주석 및 print를 제거하셨나요?
[x] javaDoc을 작성하셨나요?
[x] merge할 브랜치와 로컬에서 merge 하셨나요?
[x] 더 수정할 작업은 없는지 확인하셨나요?