### PR TITLE
Refator#225 bug websocket 메시지 전송 시 customuserdetails 관련 messageconversionexception 발생

### DIFF
--- a/src/main/java/core/global/websocket/config/WebSocketConfig.java
+++ b/src/main/java/core/global/websocket/config/WebSocketConfig.java
@@ -2,30 +2,28 @@ package core.global.websocket.config;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationListener;
-import org.springframework.context.event.ContextRefreshedEvent;
+// [!! 삭제 !!] import org.springframework.context.ApplicationListener;
+// [!! 삭제 !!] import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver; // [!!] 추가됨
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
-import org.springframework.messaging.simp.annotation.support.SimpAnnotationMethodMessageHandler;
+// [!! 삭제 !!] import org.springframework.messaging.simp.annotation.support.SimpAnnotationMethodMessageHandler;
 import org.springframework.security.messaging.context.AuthenticationPrincipalArgumentResolver;
 import org.springframework.security.messaging.context.SecurityContextChannelInterceptor;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 import org.springframework.web.socket.server.support.HttpSessionHandshakeInterceptor;
-// import org.springframework.context.annotation.Bean; // <-- 1. @Bean import가 제거됩니다.
 import org.springframework.context.annotation.Lazy;
 
-import java.util.ArrayList;
-import java.util.List;
+// [!! 삭제 !!] import java.util.ArrayList;
+import java.util.List; // [!!] 추가됨
 
 @Configuration
 @EnableWebSocketMessageBroker
 @Slf4j
-public class WebSocketConfig implements WebSocketMessageBrokerConfigurer,
-        ApplicationListener<ContextRefreshedEvent> {
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private StompChannelInterceptor stompChannelInterceptor;
 
@@ -45,18 +43,13 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer,
         this.stompChannelInterceptor = stompChannelInterceptor;
     }
 
+    /**
+     * @AuthenticationPrincipal을 처리하는 ArgumentResolver를 표준 방식으로 등록합니다.
+     */
     @Override
-    public void onApplicationEvent(ContextRefreshedEvent event) {
-        log.info("Context refreshed. Manually adding ArgumentResolver...");
-        SimpAnnotationMethodMessageHandler handler =
-                event.getApplicationContext().getBean(SimpAnnotationMethodMessageHandler.class);
-
-        List<HandlerMethodArgumentResolver> existingResolvers = handler.getArgumentResolvers();
-        List<HandlerMethodArgumentResolver> newResolvers = new ArrayList<>();
-        newResolvers.add(this.authenticationPrincipalResolver);
-        newResolvers.addAll(existingResolvers);
-        handler.setArgumentResolvers(newResolvers);
-        log.info("AuthenticationPrincipalArgumentResolver added manually after context refresh.");
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(authenticationPrincipalResolver);
+        log.info("AuthenticationPrincipalArgumentResolver added via addArgumentResolvers.");
     }
 
     @Override

--- a/src/main/java/core/global/websocket/config/WebSocketConfig.java
+++ b/src/main/java/core/global/websocket/config/WebSocketConfig.java
@@ -2,13 +2,11 @@ package core.global.websocket.config;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-// [!! 삭제 !!] import org.springframework.context.ApplicationListener;
-// [!! 삭제 !!] import org.springframework.context.event.ContextRefreshedEvent;
+
 import org.springframework.context.annotation.Configuration;
-import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver; // [!!] 추가됨
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
-// [!! 삭제 !!] import org.springframework.messaging.simp.annotation.support.SimpAnnotationMethodMessageHandler;
 import org.springframework.security.messaging.context.AuthenticationPrincipalArgumentResolver;
 import org.springframework.security.messaging.context.SecurityContextChannelInterceptor;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
@@ -17,8 +15,8 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 import org.springframework.web.socket.server.support.HttpSessionHandshakeInterceptor;
 import org.springframework.context.annotation.Lazy;
 
-// [!! 삭제 !!] import java.util.ArrayList;
-import java.util.List; // [!!] 추가됨
+
+import java.util.List;
 
 @Configuration
 @EnableWebSocketMessageBroker


### PR DESCRIPTION
### PR 변경사항
WebSocketConfig에서 AuthenticationPrincipalArgumentResolver를 등록하는 방식을 Spring 표준 방식으로 변경했습니다.


### 🖌️ 구체적인 구현 내용
[문제 원인] ApplicationListener<ContextRefreshedEvent>를 구현하고 onApplicationEvent 내부에서 AuthenticationPrincipalArgumentResolver를 수동으로 등록하는 방식이, Spring Security의 표준 웹소켓 자동 설정과 충돌을 일으켰습니다.
이로 인해 StompChannelInterceptor가 accessor.setUser(auth)를 올바르게 호출했음에도 불구하고, SecurityContext가 컨트롤러에 전달되지 않았습니다.

[구현 내용]

WebSocketConfig에서 ApplicationListener<ContextRefreshedEvent> 인터페이스 구현을 제거했습니다.

onApplicationEvent 메소드를 삭제했습니다.

WebSocketMessageBrokerConfigurer의 addArgumentResolvers 메소드를 오버라이드하여, 이 메소드 내에서 AuthenticationPrincipalArgumentResolver를 등록하도록 변경했습니다.

### ✨개선 사항 및 참고 사항
Spring 웹소켓 및 Security의 표준 구성 방식을 따르도록 수정하였습니다.

### 💯 테스트


### 확인
[x] 주석 및 print를 제거하셨나요?
[x] javaDoc 을 작성하셨나요?
[x] merge할 브랜치와 로컬에서 merge 하셨나요?
[x] 더 수정할 작업은 없는지 확인하셨나요?