### PR TITLE
Fix/#272 new user notification error

### DIFF
--- a/src/main/java/core/domain/user/service/UserService.java
+++ b/src/main/java/core/domain/user/service/UserService.java
@@ -363,7 +363,6 @@ public class UserService {
         redisService.saveRefreshToken(u.getId(), refreshToken, expirationMillis);
 
         publisher.publishEvent(new UserLoggedInEvent(u.getId().toString(), "local"));
-        publisher.publishEvent(new NewUserJoinedEvent(u.getId()));
         return new LoginResponseDto(u.getId(), accessToken, refreshToken, u.isNewUser());
     }
 
@@ -374,7 +373,6 @@ public class UserService {
     }
 
     private String buildLocalSocialId(String email) {
-        // 결정적(동일 이메일이면 동일 결과) + 노출 안전하게 해시
         return "local:" + sha256Hex(email);
     }
 
@@ -601,10 +599,9 @@ public class UserService {
 
     @Transactional
     public LoginResponseDto finalizeSkipSetupAndReissueToken(UserUpdateDto dto) {
-        // 1) 기존 로직 수행 (필드 업데이트)
+
         updateSkipUserSetup(dto);
 
-        // 2) 현재 사용자 로드
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         if (auth == null || !auth.isAuthenticated() || auth instanceof AnonymousAuthenticationToken) {
             throw new BusinessException(ErrorCode.EMAIL_NOT_AVAILABLE);
@@ -614,30 +611,18 @@ public class UserService {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-
-        // 3) VISITOR -> USER 승급
-        // 3) [삭제] VISITOR -> USER 승급 로직 (엔티티가 이미 처리함)
-        /*
-        if (user.getUserRole() == Role.VISITOR) {
-            user.changeUserRole(Role.USER);
-        }
-        */
-        // (JPA가 @Transactional에 의해 자동으로 save/flush 해줄 것임)
-
-        // 4) 새 accessToken 발급 (엔티티가 결정한 현재 role 사용)
         String accessToken = jwtTokenProvider.createAccessToken(
                 user.getId(),
-                user.getUserRole().name(), // user 객체의 최신 role을 그대로 읽음
+                user.getUserRole().name(),
                 user.getEmail()
         );
-        // 5) 리프레시 토큰
         String refreshToken = redisService.getRefreshToken(user.getId());
         if (refreshToken == null) {
             refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
             long ttlMs = jwtTokenProvider.getExpiration(refreshToken).getTime() - System.currentTimeMillis();
             redisService.saveRefreshToken(user.getId(), refreshToken, ttlMs);
         }
-
+        publisher.publishEvent(new NewUserJoinedEvent(user.getId()));
         return new LoginResponseDto(
                 user.getId(),
                 accessToken,

--- a/src/main/java/core/global/service/GoogleAuthService.java
+++ b/src/main/java/core/global/service/GoogleAuthService.java
@@ -1,7 +1,6 @@
 package core.global.service;
 
 
-import core.domain.notification.dto.NewUserJoinedEvent;
 import core.domain.user.entity.User;
 import core.domain.user.service.UserService;
 import core.global.security.JwtTokenProvider;
@@ -45,10 +44,6 @@ public class GoogleAuthService {
         redisService.saveRefreshToken(user.getId(), refreshToken, expirationMillis);
 
         boolean isNewUserResponse = user.isNewUser();
-        if (isNewUserResponse) {
-            publisher.publishEvent(new NewUserJoinedEvent(user.getId()));
-        }
-
         publisher.publishEvent(new UserLoggedInEvent(user.getId().toString(), "google"));
 
         return new LoginResponseDto(user.getId(), accessToken, refreshToken, isNewUserResponse);

--- a/src/main/resources/db/migration/V202051112__V2_notification_string.sql
+++ b/src/main/resources/db/migration/V202051112__V2_notification_string.sql
@@ -1,0 +1,16 @@
+ALTER TABLE notification
+DROP CONSTRAINT IF EXISTS notification_notification_type_check;
+
+ALTER TABLE notification
+    ADD CONSTRAINT notification_notification_type_check
+        CHECK (
+            notification_type IN (
+                                  'post',
+                                  'comment',
+                                  'chat',
+                                  'follow',
+                                  'receive',
+                                  'newuser',        --
+                                  'followuserpost'  --
+                )
+            );


### PR DESCRIPTION
# 📄 PR 변경사항
[DB] notification 테이블의 CHECK 제약 조건에 신규 알림 타입 추가 (Flyway 스크립트)
[Fix] 신규 알림(newuser, followuserpost) 저장 시 발생하던 DataIntegrityViolationException 버그 해결

# 🖌️ 구체적인 구현 내용
db/migration에 notification 테이블의 CHECK 제약 조건을 갱신하는 신규 Flyway 스크립트(V(날짜)__Update_notification_type_check.sql)를 추가했습니다.

NotificationType.java Enum에 정의된 모든 알림 타입 (post, comment, chat, follow, receive, newuser, followuserpost)을 notification_notification_type_check 제약 조건의 IN(...) 목록에 포함시켰습니다.

이전에 user_notification_setting 테이블에만 적용되었던 변경 사항을, 실제 알림 데이터가 저장되는 notification 테이블에도 동일하게 적용하여 스키마 불일치를 해결했습니다.

- 

# ✨개선 사항 및 참고 사항
이 PR은 #272 [BUG]신규유저 알람 오류를 해결합니다.
- 


# 💯 테스트
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 

# 확인
- [ ] 주석 및 print를 제거하셨나요?
- [ ] javaDoc을 작성하셨나요?
- [ ] merge할 브랜치와 로컬에서 merge 하셨나요?
- [ ] 더 수정할 작업은 없는지 확인하셨나요?
