### PR TITLE
refator(recommend): 국적 및 최근 활동 기반으로 친구 추천 로직 개편

### DIFF
--- a/src/main/java/core/domain/user/service/ContentBasedRecommender.java
+++ b/src/main/java/core/domain/user/service/ContentBasedRecommender.java
@@ -10,18 +10,15 @@ import core.global.enums.ImageType;
 import core.global.exception.BusinessException;
 import core.global.enums.errorcode.UserErrorCode;
 import core.global.entity.image.repository.ImageRepository;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+import lombok.AllArgsConstructor; // [추가]
+import lombok.Getter; // [추가]
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.Period;
-import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
+import java.time.Instant; // [추가]
+import java.time.temporal.ChronoUnit; // [추가]
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -35,19 +32,16 @@ public class ContentBasedRecommender {
     private final BlockRepository blockRepository;
     private final FollowRepository followRepository;
 
-    private static final double W_PURPOSE   = 0.35;
-    private static final double W_COUNTRY   = 0.15;
-    private static final double W_AGE       = 0.25;
-    private static final double W_LANG      = 0.10;
-    private static final double W_ACTIVITY  = 0.15;
-
+    private static final double KOREAN_PRIORITY_BOOST = 0.5;
     private static final double TEMPERATURE = 0.7;
-    private static final double ACTIVITY_SCORE_HALF_LIFE_DAYS = 7.0;
-
+    private static final double ACTIVITY_SCORE_HALF_LIFE_DAYS = 1.0;
     private static final java.security.SecureRandom RAND = new java.security.SecureRandom();
+
+
 
     @Transactional(readOnly = true)
     public List<CommendUsersProfileResponse> recommendForUser(Long meId, int limit) {
+
         User me = userRepository.findById(meId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
@@ -68,18 +62,53 @@ public class ContentBasedRecommender {
             return List.of();
         }
 
-        int meAge = safeAge(me.getBirthdate());
-        Set<String> meLangs = csvToSet(me.getLanguage());
+        boolean meIsKorean = isKorean(me.getCountry());
 
-        List<Scored<User>> scored = allCandidates.stream()
-                .map(candidate -> new Scored<>(candidate, score(me, candidate, meAge, meLangs)))
-                .collect(Collectors.toList());
+        List<Scored<User>> scoredCandidates;
 
-        List<User> chosen = pickGumbelTopK(scored, limit, TEMPERATURE);
+        if (meIsKorean) {
+            scoredCandidates = allCandidates.stream()
+                    .filter(user -> !isKorean(user.getCountry()))
+                    .map(user -> new Scored<>(
+                            user,
+                            calculateActivityScore(user, ACTIVITY_SCORE_HALF_LIFE_DAYS)
+                    ))
+                    .collect(Collectors.toList());
 
+        } else {
+            scoredCandidates = allCandidates.stream()
+                    .map(user -> {
+                        double activityScore = calculateActivityScore(user, ACTIVITY_SCORE_HALF_LIFE_DAYS);
+                        double boost = isKorean(user.getCountry()) ? KOREAN_PRIORITY_BOOST : 0.0;
+                        return new Scored<>(user, activityScore + boost);
+                    })
+                    .collect(Collectors.toList());
+        }
+
+        if (scoredCandidates.isEmpty()) {
+            return List.of();
+        }
+
+        List<User> chosen = pickGumbelTopK(scoredCandidates, limit, TEMPERATURE);
         return chosen.stream().map(this::toDto).toList();
     }
 
+    /**
+     * [신규 헬퍼 메서드]
+     * 국가 문자열을 기반으로 한국인 여부를 판단합니다.
+     * TODO: DB에 저장된 실제 '한국' 값으로 변경하세요 (예: "KR", "Republic of Korea" 등)
+     */
+    private boolean isKorean(String country) {
+        if (country == null || country.isBlank()) {
+            return false;
+        }
+        String c = country.trim();
+        return "South Korea".equalsIgnoreCase(c) || "Korea".equalsIgnoreCase(c);
+    }
+
+
+    @Getter @AllArgsConstructor
+    private static class Scored<T> { private T item; private double score; }
 
     /** Gumbel-Top-k: key = score/T + Gumbel(0,1) 로 정렬 → 상위 limit 선택(중복 없음) */
     private List<User> pickGumbelTopK(List<Scored<User>> pool, int limit, double temperature) {
@@ -96,24 +125,7 @@ public class ContentBasedRecommender {
         return draws.stream().limit(Math.max(1, limit)).map(d -> d.u).toList();
     }
 
-    /** [수정] 활동 점수를 포함하고, 'me'의 불완전 프로필을 처리하는 최종 점수 계산 메서드 */
-    private double score(User me, User other, int meAge, Set<String> meLangs) {
-        double purposeScore = (me.getPurpose() == null || me.getPurpose().isBlank())
-                ? 0.5 : (eq(me.getPurpose(), other.getPurpose()) ? 1.0 : 0.0);
-        double countryScore = (me.getCountry() == null || me.getCountry().isBlank())
-                ? 0.5 : (eq(me.getCountry(), other.getCountry()) ? 1.0 : 0.0);
-
-        double ageScore = ageSim(meAge, safeAge(other.getBirthdate()), 9.0);
-        double langScore = jaccard(meLangs, csvToSet(other.getLanguage()));
-        double activityScore = calculateActivityScore(other, ACTIVITY_SCORE_HALF_LIFE_DAYS);
-        return W_PURPOSE * purposeScore
-                + W_COUNTRY * countryScore
-                + W_AGE * ageScore
-                + W_LANG * langScore
-                + W_ACTIVITY * activityScore;
-    }
-
-    /** [추가] 사용자의 마지막 활동 시간(lastSeenAt)을 바탕으로 0.0 ~ 1.0 사이의 활동 점수를 계산 */
+    /** 사용자의 마지막 활동 시간(lastSeenAt)을 바탕으로 0.0 ~ 1.0 사이의 활동 점수를 계산 */
     private double calculateActivityScore(User user, double halfLifeDays) {
         if (user.getLastSeenAt() == null) {
             return 0.0;
@@ -123,14 +135,6 @@ public class ContentBasedRecommender {
         double decayRate = Math.log(2) / halfLifeDays;
         return Math.exp(-decayRate * daysSinceUpdate);
     }
-    private double ageSim(int a, int b, double sigma) {
-        if (a <= 0 || b <= 0) return 0.5;
-        return Math.exp(-Math.abs(a - b) / sigma);
-    }
-
-    private boolean eq(String a, String b) {
-        return a != null && b != null && a.trim().equalsIgnoreCase(b.trim());
-    }
 
     private Set<String> csvToSet(String csv) {
         if (csv == null || csv.isBlank()) return Set.of();
@@ -139,35 +143,6 @@ public class ContentBasedRecommender {
                 .filter(s -> !s.isBlank())
                 .collect(Collectors.toSet());
     }
-
-    private double jaccard(Set<String> A, Set<String> B) {
-        if (!A.isEmpty() || !B.isEmpty()) {
-            Set<String> inter = new HashSet<>(A);
-            inter.retainAll(B);
-            Set<String> uni = new HashSet<>(A);
-            uni.addAll(B);
-            return uni.isEmpty() ? 0.0 : (double) inter.size() / (double) uni.size();
-        }
-        return 0.5;
-    }
-
-    private int safeAge(String birth) {
-        if (birth == null || birth.isBlank()) {
-            return -1;
-        }
-        try {
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy");
-            LocalDate d = LocalDate.parse(birth, formatter);
-            return Period.between(d, LocalDate.now()).getYears();
-        } catch (Exception e) {
-            log.error(">>>> 잘못된 날짜 형식으로 나이 계산 실패: {}", birth, e);
-            return -1;
-        }
-    }
-
-    @Getter @AllArgsConstructor
-    private static class Scored<T> { private T item; private double score; }
-
 
     private CommendUsersProfileResponse toDto(User u) {
         String imageKey = imageRepository.findFirstByImageTypeAndRelatedIdOrderByOrderIndexAsc(ImageType.USER, u.getId())


### PR DESCRIPTION
# 📄 PR 변경사항
친구 추천 로직을 기존의 복합 콘텐츠 기반에서 '국적' 및 '최근 활동 시간' 중심으로 전면 개편합니다.
활동 점수 반감기(Half-life)를 7일에서 1일로 대폭 단축하여 최근 접속자 노출을 극대화합니다.

# 🖌️ 구체적인 구현 내용
Gumbel-Top-k 샘플링 로직을 다시 도입하여, 점수 기반의 우선순위를 부여하되 적절한 무작위성을 섞어 추천 목록을 생성합니다.
활동 점수(Activity Score) 계산 로직(calculateActivityScore)을 복원하고, 반감기를 1일로 설정하여 하루만 지나도 점수가 절반으로 감소하도록 수정했습니다.
기존의 나이, 목적, 언어 등 복잡한 가중치 점수 로직은 모두 제거했습니다.



# ✨개선 사항 및 참고 사항
이번 변경은 앱 활성화 초기에 사용자 간의 매칭을 촉진하기 위해 최근 접속자를 최우선으로 고려하도록 설계되었습니다.
ContentBasedRecommender의 KOREAN_PRIORITY_BOOST와 ACTIVITY_SCORE_HALF_LIFE_DAYS 상수를 조정하여 향후 추천 강도를 튜닝할 수 있습니다.
isKorean() 헬퍼 메서드에 정의된 국가 문자열(예: "South Korea")이 DB에 저장된 실제 데이터와 일치하는지 확인이 필요합니다.




# 💯 테스트
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->

# 확인
- [ ] 주석 및 print를 제거하셨나요?
- [ ] javaDoc을 작성하셨나요?
- [ ] merge할 브랜치와 로컬에서 merge 하셨나요?
- [ ] 더 수정할 작업은 없는지 확인하셨나요?
