### PR TITLE
bugfix: bookmark 체크 쿼리 수정

### DIFF
--- a/src/main/java/core/domain/post/repository/impl/PostRepositoryImpl.java
+++ b/src/main/java/core/domain/post/repository/impl/PostRepositoryImpl.java
@@ -685,6 +685,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 .from(bookmark)
                 .where(
                         bookmark.user.id.eq(viewerId)
+                                .and(bookmark.post.id.eq(post.id))
                 )
 
                 .exists();
@@ -697,6 +698,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 .from(bookmark)
                 .where(
                         bookmark.user.email.eq(email)
+                                .and(bookmark.post.id.eq(post.id))
                 )
                 .exists();
     }


### PR DESCRIPTION
# 📄 PR 변경사항
- bookmark 체크 쿼리 수정

# 🖌️ 구체적인 구현 내용
<!--  어떤 점을 고려하여 구현하였는지, 어떤 예외를 던지는지 등의 내용을 알려주세요! -->
- bookmark 체크 쿼리 수정
private Expression<Boolean> bookmarkedByViewerEmail(String  email) {
        if (email == null) return Expressions.FALSE; // 비로그인
        return JPAExpressions
                .selectOne()
                .from(bookmark)
                .where(
                        bookmark.user.email.eq(email)
                                .and(bookmark.post.id.eq(post.id))
                )
                .exists();
    }

post.id = bookmark.post.id where문 추가

# ✨개선 사항 및 참고 사항
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 


# 💯 테스트
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 

# 확인
- [ ] 주석 및 print를 제거하셨나요?
- [ ] javaDoc을 작성하셨나요?
- [ ] merge할 브랜치와 로컬에서 merge 하셨나요?
- [ ] 더 수정할 작업은 없는지 확인하셨나요?
