### PR TITLE
Bugfix/358 크롤링시 키 삽입 중복 실패 오류

### DIFF
--- a/src/main/java/core/domain/post/service/AllkpopCrawlerService.java
+++ b/src/main/java/core/domain/post/service/AllkpopCrawlerService.java
@@ -8,6 +8,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -120,8 +121,13 @@ public class AllkpopCrawlerService {
                         SOURCE_SITE,
                         imageUrls
                 );
-                crawledDataRepository.save(crawledData);
-                log.info("Successfully crawled and saved: {}", originalUrl);
+
+                try {
+                    crawledDataRepository.save(crawledData);
+                    log.info("Successfully crawled and saved: {}", originalUrl);
+                } catch (DataIntegrityViolationException e) {
+                    log.warn("Duplicate entry found for URL: {}. Skipping.", originalUrl);
+                }
 
                 Thread.sleep(3000);
             }

--- a/src/main/java/core/domain/post/service/HarpersBazaarCrawlerService.java
+++ b/src/main/java/core/domain/post/service/HarpersBazaarCrawlerService.java
@@ -9,6 +9,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -134,8 +135,13 @@ public class HarpersBazaarCrawlerService {
                         SOURCE_SITE,
                         imageUrls
                 );
-                crawledDataRepository.save(crawledData);
-                log.info("Successfully crawled and saved: {}", originalUrl);
+
+                try {
+                    crawledDataRepository.save(crawledData);
+                    log.info("Successfully crawled and saved: {}", originalUrl);
+                } catch (DataIntegrityViolationException e) {
+                    log.warn("Duplicate entry found for URL: {}. Skipping.", originalUrl);
+                }
 
                 Thread.sleep(3000);
             }

--- a/src/main/java/core/domain/post/service/KLifeInformationCrawlerService.java
+++ b/src/main/java/core/domain/post/service/KLifeInformationCrawlerService.java
@@ -9,6 +9,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -124,8 +125,13 @@ public class KLifeInformationCrawlerService {
                         SOURCE_SITE,
                         imageUrls
                 );
-                crawledDataRepository.save(crawledData);
-                log.info("Successfully crawled and saved: {}", originalUrl);
+
+                try {
+                    crawledDataRepository.save(crawledData);
+                    log.info("Successfully crawled and saved: {}", originalUrl);
+                } catch (DataIntegrityViolationException e) {
+                    log.warn("Duplicate entry found for URL: {}. Skipping.", originalUrl);
+                }
 
                 Thread.sleep(3000);
 

--- a/src/main/java/core/domain/post/service/MyDramaListCrawlerService.java
+++ b/src/main/java/core/domain/post/service/MyDramaListCrawlerService.java
@@ -13,6 +13,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -48,7 +49,6 @@ public class MyDramaListCrawlerService {
     public void crawlMyDramaList() {
         log.info("Starting mydramalist.com crawling with HtmlUnit...");
 
-        // 1. 기본 로거 끄기 (기존 코드)
         Logger.getLogger("org.htmlunit").setLevel(Level.OFF);
         Logger.getLogger("org.htmlunit.javascript").setLevel(Level.OFF);
         Logger.getLogger("org.htmlunit.css").setLevel(Level.OFF);
@@ -154,8 +154,13 @@ public class MyDramaListCrawlerService {
                         SOURCE_SITE,
                         List.of(imageUrl)
                 );
-                crawledDataRepository.save(crawledData);
-                log.info("Successfully crawled and saved: {}", originalUrl);
+
+                try {
+                    crawledDataRepository.save(crawledData);
+                    log.info("Successfully crawled and saved: {}", originalUrl);
+                } catch (DataIntegrityViolationException e) {
+                    log.warn("Duplicate entry found for URL: {}. Skipping.", originalUrl);
+                }
 
                 Thread.sleep(3000);
             }

--- a/src/main/java/core/domain/post/service/SoompiCrawlerService.java
+++ b/src/main/java/core/domain/post/service/SoompiCrawlerService.java
@@ -9,6 +9,7 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.parser.Parser;
 import org.jsoup.select.Elements;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -61,7 +62,6 @@ public class SoompiCrawlerService {
                 Element titleElement = articleElement.selectFirst(RSS_TITLE_SELECTOR);
 
                 if (linkElement == null || titleElement == null) {
-                    log.warn("Skipping RSS item, <link> or <title> tag not found.");
                     continue;
                 }
 
@@ -97,7 +97,6 @@ public class SoompiCrawlerService {
                             if (!text.startsWith("Source (") &&
                                     !text.startsWith("In the meantime, watch") &&
                                     !p.hasClass("has-text-align-center")) {
-
                                 contentBuilder.append(text).append("\n\n");
                             }
                         }
@@ -109,7 +108,6 @@ public class SoompiCrawlerService {
 
                     if(fullContent.isEmpty()) {
                         fullContent = title;
-                        log.warn("Could not find detail content selector [{}], using title instead.", DETAIL_CONTENT_WRAPPER);
                     }
                 } catch (IOException e) {
                     log.error("Failed to crawl detail page: {}. Skipping.", originalUrl, e);
@@ -124,8 +122,13 @@ public class SoompiCrawlerService {
                         SOURCE_SITE,
                         imageUrls
                 );
-                crawledDataRepository.save(crawledData);
-                log.info("Successfully crawled and saved: {}", originalUrl);
+
+                try {
+                    crawledDataRepository.save(crawledData);
+                    log.info("Successfully crawled and saved: {}", originalUrl);
+                } catch (DataIntegrityViolationException e) {
+                    log.warn("Duplicate entry found for URL: {}. Skipping.", originalUrl);
+                }
 
                 Thread.sleep(3000);
             }
@@ -135,7 +138,6 @@ public class SoompiCrawlerService {
             if (e instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
             }
-            throw new RuntimeException("Soompi 크롤링 실패: " + e.getMessage(), e);
         }
         log.info("Finished soompi.com crawling.");
     }

--- a/src/main/java/core/domain/post/service/crawling/KLifeCrawlerService.java
+++ b/src/main/java/core/domain/post/service/crawling/KLifeCrawlerService.java
@@ -8,6 +8,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -98,8 +99,12 @@ public class KLifeCrawlerService {
                         SOURCE_SITE,
                         imageUrls
                 );
-                crawledDataRepository.save(crawledData);
-                log.info("Successfully crawled and saved: {}", originalUrl);
+                try {
+                    crawledDataRepository.save(crawledData);
+                    log.info("Successfully crawled and saved: {}", originalUrl);
+                } catch (DataIntegrityViolationException e) {
+                    log.warn("Duplicate entry found for URL: {}. Skipping.", originalUrl);
+                }
 
                 Thread.sleep(3000);
             }

--- a/src/main/java/core/domain/post/service/crawling/KoreaNetCrawlerService.java
+++ b/src/main/java/core/domain/post/service/crawling/KoreaNetCrawlerService.java
@@ -8,6 +8,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -87,8 +88,12 @@ public class KoreaNetCrawlerService {
                     List<String> imageUrls = new ArrayList<>(imageUrlSet);
 
                     CrawledData crawledData = new CrawledData(title, fullContent, originalUrl, SOURCE_SITE, imageUrls);
-                    crawledDataRepository.save(crawledData);
-                    log.info("Successfully crawled and saved: {}", originalUrl);
+                    try {
+                        crawledDataRepository.save(crawledData);
+                        log.info("Successfully crawled and saved: {}", originalUrl);
+                    } catch (DataIntegrityViolationException e) {
+                        log.warn("Duplicate entry found for URL: {}. Skipping.", originalUrl);
+                    }
 
                 } catch (IOException e) {
                     log.error("Failed to crawl detail page: {}", originalUrl, e);

--- a/src/main/java/core/domain/post/service/crawling/SeoulGlobalCrawlerService.java
+++ b/src/main/java/core/domain/post/service/crawling/SeoulGlobalCrawlerService.java
@@ -10,6 +10,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -117,8 +118,12 @@ public class SeoulGlobalCrawlerService {
                         imageUrls
                 );
 
-                crawledDataRepository.save(crawledData);
-                log.info("Successfully crawled, translated, and saved: {}", originalUrl);
+                try {
+                    crawledDataRepository.save(crawledData);
+                    log.info("Successfully crawled and saved: {}", originalUrl);
+                } catch (DataIntegrityViolationException e) {
+                    log.warn("Duplicate entry found for URL: {}. Skipping.", originalUrl);
+                }
 
                 Thread.sleep(3000);
 


### PR DESCRIPTION
# 📄 PR 변경사항
- DB 중복 키 오류(DataIntegrityViolationException)를 방지하는 try-catch 로직 모든 크롤러 서비스에 적용

# 🖌️ 구체적인 구현 내용
<!--  어떤 점을 고려하여 구현하였는지, 어떤 예외를 던지는지 등의 내용을 알려주세요! -->
- 

# ✨개선 사항 및 참고 사항
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 


# 💯 테스트
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 

# 확인
- [ ] 주석 및 print를 제거하셨나요?
- [ ] javaDoc을 작성하셨나요?
- [ ] merge할 브랜치와 로컬에서 merge 하셨나요?
- [ ] 더 수정할 작업은 없는지 확인하셨나요?
