### PR TITLE
Bugfix/356 크롤링 Hikari leak Warn 방지

### DIFF
--- a/src/main/java/core/domain/post/service/AllkpopCrawlerService.java
+++ b/src/main/java/core/domain/post/service/AllkpopCrawlerService.java
@@ -34,11 +34,8 @@ public class AllkpopCrawlerService {
     private static final String LINK_SELECTOR = "div.text div.title a";
     private static final String THUMBNAIL_SELECTOR = "div.image img.b-lazy";
     private static final String DETAIL_CONTENT_SELECTOR = "div.entry_content";
-    private static final String DETAIL_IMAGE_SELECTOR = "div.entry_content img";
-
 
     @Scheduled(cron = "0 30 6 * * *")
-    @Transactional
     public void crawlAllkpopNews() {
         log.info("Starting allkpop.com news crawling...");
         try {
@@ -122,12 +119,7 @@ public class AllkpopCrawlerService {
                         imageUrls
                 );
 
-                try {
-                    crawledDataRepository.save(crawledData);
-                    log.info("Successfully crawled and saved: {}", originalUrl);
-                } catch (DataIntegrityViolationException e) {
-                    log.warn("Duplicate entry found for URL: {}. Skipping.", originalUrl);
-                }
+                saveCrawledData(crawledData);
 
                 Thread.sleep(3000);
             }
@@ -137,5 +129,15 @@ public class AllkpopCrawlerService {
             Thread.currentThread().interrupt();
         }
         log.info("Finished allkpop.com community crawling.");
+    }
+
+    @Transactional
+    public void saveCrawledData(CrawledData data) {
+        try {
+            crawledDataRepository.save(data);
+            log.info("Successfully crawled and saved: {}", data.getOriginalUrl());
+        } catch (DataIntegrityViolationException e) {
+            log.warn("Duplicate entry found. Skipping.");
+        }
     }
 }

--- a/src/main/java/core/domain/post/service/HarpersBazaarCrawlerService.java
+++ b/src/main/java/core/domain/post/service/HarpersBazaarCrawlerService.java
@@ -44,7 +44,6 @@ public class HarpersBazaarCrawlerService {
     private static final String USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36";
 
     @Scheduled(cron = "0 0 9 * * *")
-    @Transactional
     public void crawlHarpersBazaar() {
         log.info("Starting harpersbazaar.co.kr crawling (AJAX)...");
         try {
@@ -136,12 +135,7 @@ public class HarpersBazaarCrawlerService {
                         imageUrls
                 );
 
-                try {
-                    crawledDataRepository.save(crawledData);
-                    log.info("Successfully crawled and saved: {}", originalUrl);
-                } catch (DataIntegrityViolationException e) {
-                    log.warn("Duplicate entry found for URL: {}. Skipping.", originalUrl);
-                }
+                saveCrawledData(crawledData);
 
                 Thread.sleep(3000);
             }
@@ -193,6 +187,16 @@ public class HarpersBazaarCrawlerService {
             return responseCode == HttpURLConnection.HTTP_OK;
         } catch (Exception e) {
             return false;
+        }
+    }
+
+    @Transactional
+    public void saveCrawledData(CrawledData data) {
+        try {
+            crawledDataRepository.save(data);
+            log.info("Successfully crawled and saved: {}", data.getOriginalUrl());
+        } catch (DataIntegrityViolationException e) {
+            log.warn("Duplicate entry found. Skipping.");
         }
     }
 }

--- a/src/main/java/core/domain/post/service/KLifeInformationCrawlerService.java
+++ b/src/main/java/core/domain/post/service/KLifeInformationCrawlerService.java
@@ -42,7 +42,6 @@ public class KLifeInformationCrawlerService {
     private static final String DETAIL_IMAGE_SELECTOR = "div.rhymix_content.xe_content img";
 
     @Scheduled(cron = "0 35 5 * * *")
-    @Transactional
     public void crawlKLifeInformation() {
         log.info("Starting k-life.co /information crawling...");
         try {
@@ -126,12 +125,7 @@ public class KLifeInformationCrawlerService {
                         imageUrls
                 );
 
-                try {
-                    crawledDataRepository.save(crawledData);
-                    log.info("Successfully crawled and saved: {}", originalUrl);
-                } catch (DataIntegrityViolationException e) {
-                    log.warn("Duplicate entry found for URL: {}. Skipping.", originalUrl);
-                }
+                saveCrawledData(crawledData);
 
                 Thread.sleep(3000);
 
@@ -152,5 +146,15 @@ public class KLifeInformationCrawlerService {
             return url.substring(0, url.indexOf("?"));
         }
         return url;
+    }
+
+    @Transactional
+    public void saveCrawledData(CrawledData data) {
+        try {
+            crawledDataRepository.save(data);
+            log.info("Successfully crawled and saved: {}", data.getOriginalUrl());
+        } catch (DataIntegrityViolationException e) {
+            log.warn("Duplicate entry found. Skipping.");
+        }
     }
 }

--- a/src/main/java/core/domain/post/service/MyDramaListCrawlerService.java
+++ b/src/main/java/core/domain/post/service/MyDramaListCrawlerService.java
@@ -45,7 +45,6 @@ public class MyDramaListCrawlerService {
     private static final String USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
 
     @Scheduled(cron = "0 0 7 * * *")
-    @Transactional
     public void crawlMyDramaList() {
         log.info("Starting mydramalist.com crawling with HtmlUnit...");
 
@@ -155,12 +154,7 @@ public class MyDramaListCrawlerService {
                         List.of(imageUrl)
                 );
 
-                try {
-                    crawledDataRepository.save(crawledData);
-                    log.info("Successfully crawled and saved: {}", originalUrl);
-                } catch (DataIntegrityViolationException e) {
-                    log.warn("Duplicate entry found for URL: {}. Skipping.", originalUrl);
-                }
+                saveCrawledData(crawledData);
 
                 Thread.sleep(3000);
             }
@@ -169,5 +163,15 @@ public class MyDramaListCrawlerService {
             log.error("Error occurred during crawling mydramalist.com", e);
         }
         log.info("Finished mydramalist.com crawling.");
+    }
+
+    @Transactional
+    public void saveCrawledData(CrawledData data) {
+        try {
+            crawledDataRepository.save(data);
+            log.info("Successfully crawled and saved: {}", data.getOriginalUrl());
+        } catch (DataIntegrityViolationException e) {
+            log.warn("Duplicate entry found. Skipping.");
+        }
     }
 }

--- a/src/main/java/core/domain/post/service/SoompiCrawlerService.java
+++ b/src/main/java/core/domain/post/service/SoompiCrawlerService.java
@@ -37,7 +37,6 @@ public class SoompiCrawlerService {
     private static final String USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36";
 
     @Scheduled(cron = "0 45 6 * * *")
-    @Transactional
     public void crawlSoompiLatest() {
         log.info("Starting soompi.com latest news crawling (RSS Feed)...");
         try {
@@ -123,12 +122,7 @@ public class SoompiCrawlerService {
                         imageUrls
                 );
 
-                try {
-                    crawledDataRepository.save(crawledData);
-                    log.info("Successfully crawled and saved: {}", originalUrl);
-                } catch (DataIntegrityViolationException e) {
-                    log.warn("Duplicate entry found for URL: {}. Skipping.", originalUrl);
-                }
+                saveCrawledData(crawledData);
 
                 Thread.sleep(3000);
             }
@@ -140,5 +134,15 @@ public class SoompiCrawlerService {
             }
         }
         log.info("Finished soompi.com crawling.");
+    }
+
+    @Transactional
+    public void saveCrawledData(CrawledData data) {
+        try {
+            crawledDataRepository.save(data);
+            log.info("Successfully crawled and saved: {}", data.getOriginalUrl());
+        } catch (DataIntegrityViolationException e) {
+            log.warn("Duplicate entry found. Skipping.");
+        }
     }
 }

--- a/src/main/java/core/domain/post/service/crawling/KLifeCrawlerService.java
+++ b/src/main/java/core/domain/post/service/crawling/KLifeCrawlerService.java
@@ -37,7 +37,6 @@ public class KLifeCrawlerService {
     private static final String DETAIL_IMAGE_SELECTOR = "div.rhymix_content.xe_content img";
 
     @Scheduled(cron = "0 30 5 * * *")
-    @Transactional
     public void crawlKLifeCommunity() {
         log.info("Starting k-life.co community crawling...");
         try {
@@ -99,12 +98,8 @@ public class KLifeCrawlerService {
                         SOURCE_SITE,
                         imageUrls
                 );
-                try {
-                    crawledDataRepository.save(crawledData);
-                    log.info("Successfully crawled and saved: {}", originalUrl);
-                } catch (DataIntegrityViolationException e) {
-                    log.warn("Duplicate entry found for URL: {}. Skipping.", originalUrl);
-                }
+
+                saveCrawledData(crawledData);
 
                 Thread.sleep(3000);
             }
@@ -114,5 +109,15 @@ public class KLifeCrawlerService {
             Thread.currentThread().interrupt();
         }
         log.info("Finished k-life.co community crawling.");
+    }
+
+    @Transactional
+    public void saveCrawledData(CrawledData data) {
+        try {
+            crawledDataRepository.save(data);
+            log.info("Successfully crawled and saved: {}", data.getOriginalUrl());
+        } catch (DataIntegrityViolationException e) {
+            log.warn("Duplicate entry found. Skipping.");
+        }
     }
 }

--- a/src/main/java/core/domain/post/service/crawling/KoreaNetCrawlerService.java
+++ b/src/main/java/core/domain/post/service/crawling/KoreaNetCrawlerService.java
@@ -33,7 +33,6 @@ public class KoreaNetCrawlerService {
     private static final Pattern ARTICLE_ID_PATTERN = Pattern.compile("contentView\\(\\s*'[^']+',\\s*'(\\d+)',");
 
     @Scheduled(cron = "0 0 5 * * *")
-    @Transactional
     public void crawlKoreaNetFestivals() {
         log.info("Starting Korea.net festival crawling from HTML list...");
         try {
@@ -88,12 +87,8 @@ public class KoreaNetCrawlerService {
                     List<String> imageUrls = new ArrayList<>(imageUrlSet);
 
                     CrawledData crawledData = new CrawledData(title, fullContent, originalUrl, SOURCE_SITE, imageUrls);
-                    try {
-                        crawledDataRepository.save(crawledData);
-                        log.info("Successfully crawled and saved: {}", originalUrl);
-                    } catch (DataIntegrityViolationException e) {
-                        log.warn("Duplicate entry found for URL: {}. Skipping.", originalUrl);
-                    }
+
+                    saveCrawledData(crawledData);
 
                 } catch (IOException e) {
                     log.error("Failed to crawl detail page: {}", originalUrl, e);
@@ -109,5 +104,15 @@ public class KoreaNetCrawlerService {
             Thread.currentThread().interrupt();
         }
         log.info("Finished Korea.net festival crawling from HTML list.");
+    }
+
+    @Transactional
+    public void saveCrawledData(CrawledData data) {
+        try {
+            crawledDataRepository.save(data);
+            log.info("Successfully crawled and saved: {}", data.getOriginalUrl());
+        } catch (DataIntegrityViolationException e) {
+            log.warn("Duplicate entry found. Skipping.");
+        }
     }
 }

--- a/src/main/java/core/domain/post/service/crawling/SeoulGlobalCrawlerService.java
+++ b/src/main/java/core/domain/post/service/crawling/SeoulGlobalCrawlerService.java
@@ -38,7 +38,6 @@ public class SeoulGlobalCrawlerService {
     private static final Pattern POST_NO_PATTERN = Pattern.compile("contDetail\\('([^']+)'\\)");
 
     @Scheduled(cron = "0 0 6 * * *")
-    @Transactional
     public void crawlSeoulGlobalNews() {
         log.info("Starting Seoul Global Center news crawling...");
         try {
@@ -118,12 +117,7 @@ public class SeoulGlobalCrawlerService {
                         imageUrls
                 );
 
-                try {
-                    crawledDataRepository.save(crawledData);
-                    log.info("Successfully crawled and saved: {}", originalUrl);
-                } catch (DataIntegrityViolationException e) {
-                    log.warn("Duplicate entry found for URL: {}. Skipping.", originalUrl);
-                }
+                saveCrawledData(crawledData);
 
                 Thread.sleep(3000);
 
@@ -134,5 +128,15 @@ public class SeoulGlobalCrawlerService {
             Thread.currentThread().interrupt();
         }
         log.info("Finished Seoul Global Center crawling.");
+    }
+
+    @Transactional
+    public void saveCrawledData(CrawledData data) {
+        try {
+            crawledDataRepository.save(data);
+            log.info("Successfully crawled and saved: {}", data.getOriginalUrl());
+        } catch (DataIntegrityViolationException e) {
+            log.warn("Duplicate entry found. Skipping.");
+        }
     }
 }


### PR DESCRIPTION
# 📄 PR 변경사항
- 크롤링 서비스 트랜잭션 범위 최적화

# 🖌️ 구체적인 구현 내용
<!--  어떤 점을 고려하여 구현하였는지, 어떤 예외를 던지는지 등의 내용을 알려주세요! -->
- 모든 크롤러 서비스의 메인 로직에서 @Transactional 제거 (HikariCP connection leak 방지)
- DB 저장 로직을 별도 트랜잭션 메서드로 분리

# ✨개선 사항 및 참고 사항
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 


# 💯 테스트
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 

# 확인
- [ ] 주석 및 print를 제거하셨나요?
- [ ] javaDoc을 작성하셨나요?
- [ ] merge할 브랜치와 로컬에서 merge 하셨나요?
- [ ] 더 수정할 작업은 없는지 확인하셨나요?
