### PR TITLE
feat: 앱 버전 체크 및 강제 업데이트 API 구현

### DIFF
--- a/src/main/java/core/global/version/AppVersion.java
+++ b/src/main/java/core/global/version/AppVersion.java
@@ -1,0 +1,66 @@
+package core.global.version;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "app_version", indexes = {
+        @Index(name = "idx_app_version_platform", columnList = "platform", unique = true)
+})
+public class AppVersion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private Platform platform;
+
+    @Column(name = "minimum_version", nullable = false, length = 20)
+    private String minimumVersion;
+
+    @Column(name = "latest_version", nullable = false, length = 20)
+    private String latestVersion;
+    @Column(name = "store_url", nullable = false, length = 500)
+    private String storeUrl;
+
+    @Column(columnDefinition = "TEXT")
+    private String message;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    public AppVersion(Platform platform, String minimumVersion, String latestVersion, String storeUrl, String message) {
+        this.platform = platform;
+        this.minimumVersion = minimumVersion;
+        this.latestVersion = latestVersion;
+        this.storeUrl = storeUrl;
+        this.message = message;
+    }
+
+    public void update(String minimumVersion, String latestVersion, String storeUrl, String message) {
+        this.minimumVersion = minimumVersion;
+        this.latestVersion = latestVersion;
+        this.storeUrl = storeUrl;
+        this.message = message;
+    }
+}
+
+enum Platform {
+    ANDROID, IOS
+}

--- a/src/main/java/core/global/version/AppVersionController.java
+++ b/src/main/java/core/global/version/AppVersionController.java
@@ -1,0 +1,61 @@
+package core.global.version;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "App Version", description = "앱 버전 관리 및 강제 업데이트 체크 API")
+@RestController
+@RequestMapping("/api/v1/app")
+@RequiredArgsConstructor
+public class AppVersionController {
+
+    private final AppVersionService appVersionService;
+
+    @Operation(
+            summary = "앱 버전 체크 (스플래시 화면용)",
+            description = """
+            앱 실행 시 현재 버전을 서버에 전송하여 업데이트 필요 여부를 확인합니다.
+            
+            **로직 설명:**
+            1. **FORCE_UPDATE**: 현재 버전 < 최소 지원 버전 (앱 사용 차단)
+            2. **RECOMMEND_UPDATE**: 최소 버전 <= 현재 버전 < 최신 버전 (업데이트 권장 팝업)
+            3. **PASS**: 현재 버전 == 최신 버전 (정상 진입)
+            """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "요청 성공",
+                    content = @Content(schema = @Schema(implementation = VersionCheckDto.Response.class))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 플랫폼 정보 (ANDROID, IOS 외의 값 전송)",
+                    content = @Content(schema = @Schema(hidden = true))
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 에러 (DB에 해당 플랫폼 버전 정보가 없을 경우)",
+                    content = @Content(schema = @Schema(hidden = true))
+            )
+    })
+    @GetMapping("/version")
+    public ResponseEntity<VersionCheckDto.Response> checkVersion(
+            @Parameter(description = "앱 버전 체크 요청 파라미터")
+            @ModelAttribute VersionCheckDto.Request request
+    ) {
+        VersionCheckDto.Response response = appVersionService.checkVersion(request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/core/global/version/AppVersionRepository.java
+++ b/src/main/java/core/global/version/AppVersionRepository.java
@@ -1,0 +1,8 @@
+package core.global.version;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface AppVersionRepository extends JpaRepository<AppVersion, Long> {
+    Optional<AppVersion> findByPlatform(Platform platform);
+}

--- a/src/main/java/core/global/version/AppVersionService.java
+++ b/src/main/java/core/global/version/AppVersionService.java
@@ -1,0 +1,79 @@
+package core.global.version;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AppVersionService {
+
+    private final AppVersionRepository appVersionRepository;
+
+    @Transactional(readOnly = true)
+    public VersionCheckDto.Response checkVersion(VersionCheckDto.Request request) {
+        // 1. 플랫폼 검증 및 DB 조회
+        Platform platform;
+        try {
+            platform = Platform.valueOf(request.getPlatform().toUpperCase());
+        } catch (IllegalArgumentException | NullPointerException e) {
+            throw new IllegalArgumentException("Invalid platform: " + request.getPlatform());
+        }
+
+        AppVersion serverVersion = appVersionRepository.findByPlatform(platform)
+                .orElseThrow(() -> new IllegalStateException("버전 정보가 설정되지 않았습니다. 관리자에게 문의하세요."));
+
+        // 2. 버전 비교 실행
+        String currentVer = request.getCurrentVersion();
+
+        // Case 1: 최소 버전(minimum)보다 낮음 -> 강제 업데이트(FORCE)
+        if (compareVersion(currentVer, serverVersion.getMinimumVersion()) < 0) {
+            return VersionCheckDto.Response.builder()
+                    .status(VersionCheckDto.UpdateStatus.FORCE_UPDATE)
+                    .title("Update Required")
+                    .message(serverVersion.getMessage()) // DB에 저장된 메시지 전달
+                    .storeUrl(serverVersion.getStoreUrl())
+                    .build();
+        }
+
+        // Case 2: 최신 버전(latest)보다 낮음 -> 권장 업데이트(RECOMMEND)
+        if (compareVersion(currentVer, serverVersion.getLatestVersion()) < 0) {
+            return VersionCheckDto.Response.builder()
+                    .status(VersionCheckDto.UpdateStatus.RECOMMEND_UPDATE)
+                    .title("Update Available")
+                    .message("A new version is available. Would you like to update?")
+                    .storeUrl(serverVersion.getStoreUrl())
+                    .build();
+        }
+
+        // Case 3: 최신 버전임 -> 통과(PASS)
+        return VersionCheckDto.Response.builder()
+                .status(VersionCheckDto.UpdateStatus.PASS)
+                .build();
+    }
+
+    /**
+     * 버전 문자열 비교 유틸리티
+     * 예: 1.2.4 vs 1.2.5
+     * return < 0 : v1이 더 작음 (업데이트 필요)
+     * return 0   : 같음
+     * return > 0 : v1이 더 큼
+     */
+    private int compareVersion(String v1, String v2) {
+        if (v1 == null || v2 == null) return 0;
+
+        String[] v1Parts = v1.split("\\.");
+        String[] v2Parts = v2.split("\\.");
+
+        int length = Math.max(v1Parts.length, v2Parts.length);
+
+        for (int i = 0; i < length; i++) {
+            // 숫자가 없으면 0으로 간주 (예: 1.0 vs 1.0.0 은 같음)
+            int part1 = i < v1Parts.length ? Integer.parseInt(v1Parts[i]) : 0;
+            int part2 = i < v2Parts.length ? Integer.parseInt(v2Parts[i]) : 0;
+
+            if (part1 < part2) return -1;
+            if (part1 > part2) return 1;
+        }
+        return 0;
+    }
+}

--- a/src/main/java/core/global/version/VersionCheckDto.java
+++ b/src/main/java/core/global/version/VersionCheckDto.java
@@ -1,0 +1,44 @@
+package core.global.version;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+public class VersionCheckDto {
+
+    @Data
+    @Schema(description = "앱 버전 체크 요청 객체")
+    public static class Request {
+
+        @Schema(description = "운영체제 플랫폼 (대소문자 무관)", example = "ANDROID", allowableValues = {"ANDROID", "IOS"})
+        private String platform;
+
+        @Schema(description = "현재 설치된 앱 버전 (x.y.z 형식)", example = "1.0.0")
+        private String currentVersion;
+    }
+
+    @Data
+    @Builder
+    @Schema(description = "앱 버전 체크 응답 객체")
+    public static class Response {
+
+        @Schema(description = "업데이트 상태 (FORCE_UPDATE: 강제, RECOMMEND_UPDATE: 권장, PASS: 통과)", example = "FORCE_UPDATE")
+        private UpdateStatus status;
+
+        @Schema(description = "알림 팝업 제목", example = "Update Required")
+        private String title;
+
+        @Schema(description = "알림 팝업 내용 (줄바꿈 포함 가능)", example = "Please update to the latest version for more stable service.")
+        private String message;
+
+        @Schema(description = "스토어 이동 URL (마켓 스키마 또는 HTTPS 링크)", example = "market://details?id=com.SWYP.kori")
+        private String storeUrl;
+    }
+
+    public enum UpdateStatus {
+        FORCE_UPDATE,
+        RECOMMEND_UPDATE,
+        PASS
+    }
+}

--- a/src/main/resources/db/migration/V220251120_version_entity.sql
+++ b/src/main/resources/db/migration/V220251120_version_entity.sql
@@ -1,3 +1,4 @@
+-- 1. 테이블 생성
 CREATE TABLE app_version (
                              id BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT 'PK',
                              platform VARCHAR(20) NOT NULL COMMENT 'OS 구분 (ANDROID, IOS)',
@@ -7,9 +8,14 @@ CREATE TABLE app_version (
                              message TEXT COMMENT '업데이트 안내 문구',
                              created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6) COMMENT '생성일',
                              updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6) COMMENT '수정일',
+
+    -- 플랫폼별로 데이터는 딱 1줄씩만 존재해야 하므로 Unique Constraint 설정
                              CONSTRAINT uk_app_version_platform UNIQUE (platform)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='앱 버전 관리';
 
+-- 2. 초기 데이터 삽입
+
+-- Android (패키지명: com.SWYP.kori)
 INSERT INTO app_version (platform, minimum_version, latest_version, store_url, message, created_at, updated_at)
 VALUES (
            'ANDROID',
@@ -21,12 +27,13 @@ VALUES (
            NOW()
        );
 
+-- iOS (Apple ID: 6752611613 적용 완료)
 INSERT INTO app_version (platform, minimum_version, latest_version, store_url, message, created_at, updated_at)
 VALUES (
            'IOS',
            '1.2.4',
            '1.2.4',
-           'itms-apps://itunes.apple.com/app/id123456789',
+           'itms-apps://itunes.apple.com/app/id6752611613',
            'Please update to the latest version for more stable service.',
            NOW(),
            NOW()

--- a/src/main/resources/db/migration/V220251120_version_entity.sql
+++ b/src/main/resources/db/migration/V220251120_version_entity.sql
@@ -1,0 +1,33 @@
+CREATE TABLE app_version (
+                             id BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT 'PK',
+                             platform VARCHAR(20) NOT NULL COMMENT 'OS 구분 (ANDROID, IOS)',
+                             minimum_version VARCHAR(20) NOT NULL COMMENT '최소 지원 버전 (강제 업데이트 기준)',
+                             latest_version VARCHAR(20) NOT NULL COMMENT '최신 버전 (업데이트 권장 기준)',
+                             store_url VARCHAR(500) NOT NULL COMMENT '스토어 URL',
+                             message TEXT COMMENT '업데이트 안내 문구',
+                             created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6) COMMENT '생성일',
+                             updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6) COMMENT '수정일',
+                             CONSTRAINT uk_app_version_platform UNIQUE (platform)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='앱 버전 관리';
+
+INSERT INTO app_version (platform, minimum_version, latest_version, store_url, message, created_at, updated_at)
+VALUES (
+           'ANDROID',
+           '1.2.4',
+           '1.2.4',
+           'market://details?id=com.SWYP.kori',
+           'Please update to the latest version for more stable service.',
+           NOW(),
+           NOW()
+       );
+
+INSERT INTO app_version (platform, minimum_version, latest_version, store_url, message, created_at, updated_at)
+VALUES (
+           'IOS',
+           '1.2.4',
+           '1.2.4',
+           'itms-apps://itunes.apple.com/app/id123456789',
+           'Please update to the latest version for more stable service.',
+           NOW(),
+           NOW()
+       );


### PR DESCRIPTION
# 📄 PR 변경사항

  - **Entity 추가:** `AppVersion` (플랫폼별 버전 정보 및 스토어 URL 관리)
  - **API 구현:** `AppVersionController`, `AppVersionService` (GET `/api/v1/app/version`)
  - **DB 마이그레이션:** Flyway 스크립트 추가 (`V1__init_app_version.sql`)
  - **문서화:** Swagger(SpringDoc) 어노테이션 적용

# 🖌️ 구체적인 구현 내용

**1. 버전 체크 로직 구현 (`AppVersionService`)**

  - 클라이언트로부터 `platform`(ANDROID/IOS)과 `currentVersion`을 받아 서버의 설정값과 비교합니다.
  - **Semantic Versioning** 비교 방식을 사용하여 `1.0`과 `1.0.0`을 동일하게 처리하고, 각 자릿수(`Major.Minor.Patch`)를 정확히 비교합니다.
  - 비교 결과에 따라 3가지 상태를 반환합니다.
      - `FORCE_UPDATE`: 현재 버전 \< 최소 지원 버전 (`minimum_version`)
      - `RECOMMEND_UPDATE`: 최소 버전 \<= 현재 버전 \< 최신 버전 (`latest_version`)
      - `PASS`: 현재 버전 \>= 최신 버전

**2. 초기 데이터 및 스토어 URL 설정**

  - Flyway 스크립트를 통해 테이블 생성과 동시에 \*\*초기 데이터(v1.2.4)\*\*를 삽입하도록 구현했습니다.
  - **Android:** `market://details?id=com.SWYP.kori` (Intent 실행용)
  - **iOS:** `https://apps.apple.com/app/id6752611613` (Universal Link, 호환성 고려하여 HTTPS 적용)

**3. API 문서화 (Swagger)**

  - 프론트엔드 연동 편의를 위해 `VersionCheckDto`에 상세한 Schema 설명과 예시 값(`example`)을 추가했습니다.

# ✨개선 사항 및 참고 사항

  - **iOS URL 변경:** 기존 `itms-apps://` 스키마 대신, 웹과 앱 모두에서 안정적으로 동작하는 `https://` 링크를 DB 기본값으로 설정했습니다.
  - **관리자 기능:** 추후 어드민 페이지 개발 시 `AppVersion` 테이블을 수정하는 API만 추가하면 즉시 배포 없이 강제 업데이트 제어가 가능합니다.

# 💯 테스트

```

# 확인

  - [x] 주석 및 print를 제거하셨나요?
  - [x] javaDoc을 작성하셨나요? (Swagger Annotation으로 대체)
  - [x] merge할 브랜치와 로컬에서 merge 하셨나요?
  - [x] 더 수정할 작업은 없는지 확인하셨나요?