### PR TITLE
feat: 핵심 사용자 피드백 시스템 구현

### DIFF
--- a/src/main/java/core/global/enums/FeedbackSource.java
+++ b/src/main/java/core/global/enums/FeedbackSource.java
@@ -1,0 +1,8 @@
+package core.global.enums;
+
+
+public enum FeedbackSource {
+    CHAT,
+    COMMUNITY,
+    ETC
+}

--- a/src/main/java/core/global/userfeedback/FeedbackController.java
+++ b/src/main/java/core/global/userfeedback/FeedbackController.java
@@ -1,0 +1,35 @@
+package core.global.userfeedback;
+
+
+import core.global.userfeedback.dto.FeedbackEligibilityResponse;
+import core.global.userfeedback.dto.FeedbackRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/feedbacks")
+@RequiredArgsConstructor
+public class FeedbackController {
+
+    private final FeedbackService feedbackService;
+
+    @GetMapping("/eligibility")
+    public ResponseEntity<FeedbackEligibilityResponse> checkEligibility(
+            @AuthenticationPrincipal Long userId
+    ) {
+        boolean isEligible = feedbackService.checkEligibility(userId);
+        return ResponseEntity.ok(new FeedbackEligibilityResponse(isEligible));
+    }
+    @PostMapping
+    public ResponseEntity<Void> submitFeedback(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody @Valid FeedbackRequest request
+    ) {
+        feedbackService.createFeedback(userId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/src/main/java/core/global/userfeedback/FeedbackService.java
+++ b/src/main/java/core/global/userfeedback/FeedbackService.java
@@ -1,0 +1,46 @@
+package core.global.userfeedback;
+import core.domain.user.entity.User;
+import core.domain.user.repository.UserRepository;
+import core.global.userfeedback.dto.FeedbackRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FeedbackService {
+
+    private final UserFeedbackRepository feedbackRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 피드백 대상 여부 확인
+     * 이미 피드백을 작성한 유저라면 false 반환
+     */
+    public boolean checkEligibility(Long userId) {
+        User user = getUserOrThrow(userId);
+        return !feedbackRepository.existsByUser(user);
+    }
+
+    /**
+     * 피드백 저장
+     */
+    @Transactional
+    public void createFeedback(Long userId, FeedbackRequest request) {
+        User user = getUserOrThrow(userId);
+
+        UserFeedback feedback = UserFeedback.builder()
+                .user(user)
+                .content(request.content())
+                .source(request.source())
+                .build();
+
+        feedbackRepository.save(feedback);
+    }
+
+    private User getUserOrThrow(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+    }
+}

--- a/src/main/java/core/global/userfeedback/UserFeedback.java
+++ b/src/main/java/core/global/userfeedback/UserFeedback.java
@@ -1,0 +1,48 @@
+package core.global.userfeedback;
+
+import core.domain.user.entity.User;
+import core.global.enums.FeedbackSource;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "user_feedbacks")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class UserFeedback {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "feedback_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "source", length = 20)
+    private FeedbackSource source;
+
+    @Column(name = "content", columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private Instant createdAt;
+
+    @Builder
+    public UserFeedback(User user, FeedbackSource source, String content) {
+        this.user = user;
+        this.source = source;
+        this.content = content;
+    }
+}

--- a/src/main/java/core/global/userfeedback/UserFeedbackRepository.java
+++ b/src/main/java/core/global/userfeedback/UserFeedbackRepository.java
@@ -1,0 +1,7 @@
+package core.global.userfeedback;
+
+import core.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+public interface UserFeedbackRepository extends JpaRepository<UserFeedback, Long> {
+    boolean existsByUser(User user);
+}

--- a/src/main/java/core/global/userfeedback/dto/FeedbackEligibilityResponse.java
+++ b/src/main/java/core/global/userfeedback/dto/FeedbackEligibilityResponse.java
@@ -1,0 +1,6 @@
+package core.global.userfeedback.dto;
+
+
+public record FeedbackEligibilityResponse(
+        boolean isEligible
+) {}

--- a/src/main/java/core/global/userfeedback/dto/FeedbackRequest.java
+++ b/src/main/java/core/global/userfeedback/dto/FeedbackRequest.java
@@ -1,0 +1,13 @@
+package core.global.userfeedback.dto;
+
+import core.global.enums.FeedbackSource;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record FeedbackRequest(
+        @NotBlank(message = "내용을 입력해주세요.")
+        @Size(max = 2000, message = "2000자 이내로 입력해주세요.")
+        String content,
+
+        FeedbackSource source // 프론트에서 보내줌 (CHAT, COMMUNITY...)
+) {}

--- a/src/main/resources/db/migration/V220251120_version_entity.sql
+++ b/src/main/resources/db/migration/V220251120_version_entity.sql
@@ -27,13 +27,11 @@ VALUES (
            NOW()
        );
 
--- iOS (Apple ID: 6752611613 적용 완료)
 INSERT INTO app_version (platform, minimum_version, latest_version, store_url, message, created_at, updated_at)
 VALUES (
            'IOS',
            '1.2.4',
-           '1.2.4',
-           'itms-apps://itunes.apple.com/app/id6752611613',
+           '1.2.4','https://apps.apple.com/app/id6752611613',
            'Please update to the latest version for more stable service.',
            NOW(),
            NOW()

--- a/src/main/resources/db/migration/V220251121_create_user_feedbacks.sql
+++ b/src/main/resources/db/migration/V220251121_create_user_feedbacks.sql
@@ -1,0 +1,9 @@
+CREATE TABLE user_feedbacks (
+                                feedback_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                                user_id BIGINT NOT NULL,
+                                source VARCHAR(20),
+                                content TEXT NOT NULL,
+                                created_at DATETIME(6),
+                                CONSTRAINT fk_user_feedbacks_user FOREIGN KEY (user_id) REFERENCES users (user_id)
+);
+;


### PR DESCRIPTION

# 📄 PR 변경사항
- **UserFeedback 도메인 추가**: `UserFeedback` 엔티티, 레포지토리, DTO 구현
- **API 구현**: 피드백 가능 여부 확인(`checkEligibility`) 및 저장(`createFeedback`) 로직 추가
- **DB 마이그레이션**: `user_feedbacks` 테이블 생성용 Flyway 스크립트 추가
- **소스 구분 로직**: 피드백 유입 경로 추적을 위한 `FeedbackSource` (CHAT, COMMUNITY) Enum 적용

# 🖌️ 구체적인 구현 내용
- **심플한 데이터 구조**:
    - 초기 기획의 별점/카테고리 필드를 제거하고, 유저의 피드백(Text)과 유입 출처(Source)만 저장하도록 가볍게 설계했습니다.
- **중복 제출 방지 로직 (`FeedbackService`)**:
    - `checkEligibility`: DB 조회(`existsByUser`)를 통해 이미 피드백을 남긴 유저에게는 `false`를 반환하여 중복 작성을 원천 차단했습니다.
    - `createFeedback`: 유저 존재 여부를 검증하며, 없는 유저일 경우 `IllegalArgumentException`을 발생시킵니다.
- **확장성 고려**:
    - `FeedbackSource` Enum을 사용하여 추후 '채팅', '커뮤니티' 외에 다른 트리거 포인트가 생겨도 유연하게 대응 가능하도록 했습니다.

# ✨개선 사항 및 참고 사항
- **클라이언트 협업 포인트**:
    - 서버는 "이미 제출했는지"만 영구적으로 체크합니다.
    - "3일 뒤 다시 묻기"와 같은 쿨타임 로직은 클라이언트(앱)의 LocalStorage에서 관리하도록 협의되었습니다.
- **Flyway**: `user_id`로 조회하는 빈도가 높으므로 인덱스를 추가했습니다.


# 💯 테스트


# 확인
- [ ] 주석 및 print를 제거하셨나요?
- [ ] javaDoc을 작성하셨나요?
- [ ] merge할 브랜치와 로컬에서 merge 하셨나요?
- [ ] 더 수정할 작업은 없는지 확인하셨나요?