### PR TITLE
신규 유저 알림 발송 24초 → 0.1초 단축 (배치 적용 및 DB저장 제거)

### DIFF
--- a/src/main/java/core/domain/chat/dto/MessageSentEvent.java
+++ b/src/main/java/core/domain/chat/dto/MessageSentEvent.java
@@ -9,5 +9,6 @@ import java.util.List;
 public record MessageSentEvent(
         ChatMessageResponse messageResponse,    // 전송된 메시지 내용
         List<Long> recipientIds,                // 수신자 ID 목록
-        ChatRoomSummaryResponse roomSummary     // 갱신될 채팅방 요약 정보
+        ChatRoomSummaryResponse roomSummary   ,  // 갱신될 채팅방 요약 정보
+        long startTime //
 ) {}

--- a/src/main/java/core/domain/chat/service/ChatEventListener.java
+++ b/src/main/java/core/domain/chat/service/ChatEventListener.java
@@ -100,7 +100,12 @@ public class ChatEventListener {
                 eventPublisher.publishEvent(notificationEvent);
             }
         });
+        long currentTime = System.currentTimeMillis();
+        long totalDuration = currentTime - event.startTime();
 
+        log.info("🚀 [E2E Performance] Message {} broadcast complete.", message.id());
+        log.info("   - Recipients: {} users", event.recipientIds().size());
+        log.info("   - Total E2E Latency: {} ms (Service + DB Commit + Async Wait + Socket Push)", totalDuration);
         log.info("Message {} broadcasted via Parallel Stream to {} recipients (DB Query Skipped)",
                 message.id(), event.recipientIds().size());
     }

--- a/src/main/java/core/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/core/domain/chat/service/ChatMessageService.java
@@ -89,7 +89,7 @@ public class ChatMessageService {
         long startTime = System.currentTimeMillis();
 
         try {
-
+            long absoluteStartTime = System.currentTimeMillis();
             // 1. 메시지 저장
             ChatMessage savedMessage = this.saveMessage(req.roomId(), req.senderId(), req.content());
             ChatRoom chatRoom = savedMessage.getChatRoom();
@@ -171,18 +171,16 @@ public class ChatMessageService {
                 );
 
                 ChatRoomSummaryResponse summary = buildChatRoomSummaryResponse(chatRoom.getId(), sender.getId());
-                eventPublisher.publishEvent(new MessageSentEvent(messageResponse, recipientIds, summary));
+                eventPublisher.publishEvent(new MessageSentEvent(messageResponse, recipientIds, summary,absoluteStartTime));
 
-                chatMetrics.onMessageSent("text", true);
-                chatMetrics.recordDelivery(startTime);
+                //chatMetrics.onMessageSent("text", true);
+                //chatMetrics.recordDelivery(startTime);
 
                 long endTime = System.currentTimeMillis();
-                log.debug("Processed message for room {} in {}ms (Recipients: {})",
-                        req.roomId(), (endTime - startTime), chatRoom.getParticipants().size());
             }
         } catch (Exception e) {
-            chatMetrics.onMessageSent("text", false);
-            chatMetrics.recordDelivery(startTime);
+           // chatMetrics.onMessageSent("text", false);
+          //  chatMetrics.recordDelivery(startTime);
 
             throw e;
         }
@@ -350,6 +348,7 @@ public class ChatMessageService {
         long startTime = System.currentTimeMillis();
 
         try {
+            long absoluteStartTime = System.currentTimeMillis();
             ChatRoom chatRoom = chatRoomRepository.findById(req.roomId())
                     .orElseThrow(() -> new BusinessException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
             User sender = userRepository.findById(req.senderId())
@@ -389,13 +388,13 @@ public class ChatMessageService {
             ChatRoomSummaryResponse summary = buildChatRoomSummaryResponse(chatRoom.getId(), sender.getId());
 
             // 4. [핵심 변경] 직접 전송하지 않고 이벤트만 던집니다.
-            eventPublisher.publishEvent(new MessageSentEvent(messageResponse, recipientIds, summary));
+            eventPublisher.publishEvent(new MessageSentEvent(messageResponse, recipientIds, summary,absoluteStartTime));
 
-            chatMetrics.onMessageSent("media", true);
-            chatMetrics.recordDelivery(startTime);
+            //chatMetrics.onMessageSent("media", true);
+           // chatMetrics.recordDelivery(startTime);
         } catch (Exception e) {
-            chatMetrics.onMessageSent("media", false);
-            chatMetrics.recordDelivery(startTime);
+           // chatMetrics.onMessageSent("media", false);
+           // chatMetrics.recordDelivery(startTime);
 
             throw e;
         }

--- a/src/main/java/core/domain/notification/service/NotificationEventListener.java
+++ b/src/main/java/core/domain/notification/service/NotificationEventListener.java
@@ -1,5 +1,9 @@
 package core.domain.notification.service;
+import core.domain.userdevicetoken.repository.UserDeviceTokenRepository;
 import core.global.enums.NotificationType;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.util.StopWatch;
 import core.domain.notification.dto.NewUserJoinedEvent;
 import core.domain.notification.dto.NotificationEvent;
@@ -12,6 +16,8 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 @Slf4j
@@ -23,7 +29,7 @@ public class NotificationEventListener {
     private final UserNotificationService notificationService;
     private final PushNotificationService pushNotificationService;
     private final NotificationMessageGenerator notificationMessageGenerator;
-
+    private final UserDeviceTokenRepository userDeviceTokenRepository;
 
     @Async("dispatchExecutor")
     @EventListener
@@ -53,57 +59,71 @@ public class NotificationEventListener {
     }
 
     /**
-     * ✅ [비효율적인 버전]
-     * 신규 유저 가입 이벤트를 받아 전체 사용자에게 알림을 발송합니다.
-     * 추후 최적화 필요
+     * ✅ [최적화된 버전]
+     * DB 저장 X, 배치 발송 O, 메모리 효율 O
      */
     @Async("dispatchExecutor")
     @EventListener
-    @Transactional
-    public void handleNewUserBroadcastInefficiently(NewUserJoinedEvent event) {
-        log.info("[비효율적 방식] 신규 유저 가입 이벤트 수신. 전체 알림 발송을 시작합니다. 신규 유저 ID: {}", event.newUserId());
+    public void handleNewUserBroadcastOptimized(NewUserJoinedEvent event) {
 
-        User newUserActor = userRepository.findById(event.newUserId()).orElse(null);
-        if (newUserActor == null) {
-            log.warn("신규 유저 정보를 찾을 수 없어 전체 알림을 중단합니다. ID: {}", event.newUserId());
+        User newUser = userRepository.findById(event.newUserId()).orElse(null);
+        if (newUser == null) {
+            log.warn("신규 유저 정보를 찾을 수 없어 브로드캐스트를 중단합니다. ID: {}", event.newUserId());
             return;
         }
 
-        NotificationEvent tempEvent = new NotificationEvent(
-                null, newUserActor.getId(),
-                NotificationType.newuser,
-                newUserActor.getId(), null, null);
-        String message = notificationMessageGenerator.generateMessage(newUserActor, tempEvent);
-
-        // 1. 전체 유저 조회 (메모리 경고 지점)
-        List<User> allUsers = userRepository.findAll();
-        log.warn("[성능 경고] {}명의 모든 사용자를 메모리에 로드했습니다. 사용자 수가 많을 경우 OutOfMemoryError가 발생할 수 있습니다.", allUsers.size());
-
-        // 2. 시간 측정 시작 (스프링 StopWatch 사용)
+        log.info("📢 신규 유저({}) 브로드캐스트 시작", newUser.getId());
         StopWatch stopWatch = new StopWatch();
         stopWatch.start();
 
-        // 3. 루프 돌며 발송
-        for (User recipient : allUsers) {
-            if (recipient.getId().equals(newUserActor.getId())) {
-                continue;
+        List<String> targetCountries = List.of("South Korea", "KR", "Korea");
+        Instant activeSince = Instant.now().minus(7, ChronoUnit.DAYS);
+        NotificationType notiType = NotificationType.newuser;
+
+        String title = "New friend arrived! 👋";
+        String body = determineMessageInEnglish(newUser);
+
+        int batchSize = 500;
+        Pageable pageable = PageRequest.of(0, batchSize);
+        int totalSent = 0;
+
+        while (true) {
+            Slice<String> tokenSlice = userDeviceTokenRepository.findTokensForBroadcast(
+                    targetCountries, activeSince, notiType, pageable
+            );
+
+            List<String> tokens = tokenSlice.getContent();
+
+            if (!tokens.isEmpty()) {
+                // DB 저장 없이 바로 푸시 발송
+                pushNotificationService.sendBatchPush(tokens, title, body, newUser.getId());
+                totalSent += tokens.size();
             }
 
-            try {
-                notificationService.createAndSaveNotification(recipient, newUserActor, tempEvent, message);
-                pushNotificationService.sendPushNotification(recipient, tempEvent, message);
-            } catch (Exception e) {
-                log.error("사용자 ID {}에게 신규 유저 알림 발송 중 오류 발생", recipient.getId(), e);
-            }
+            if (!tokenSlice.hasNext()) break;
+            pageable = tokenSlice.nextPageable();
         }
 
-        // 4. 시간 측정 종료 및 로그 출력
         stopWatch.stop();
-        log.info("========== [알림 발송 성능 측정] ==========");
+        log.info("========== [브로드캐스트 결과] ==========");
         log.info("총 소요 시간: {} 초", stopWatch.getTotalTimeSeconds());
-        log.info("처리한 유저 수: {} 명", allUsers.size());
+        log.info("발송 건수: {} 건", totalSent);
         log.info("========================================");
+    }
 
-        log.info("[비효율적 방식] 전체 알림 발송 루프 완료. 총 {}명 처리.", allUsers.size());
+    private String determineMessageInEnglish(User newUser) {
+        String country = newUser.getCountry();
+        if (country == null || country.isBlank()) {
+            return "A new friend has joined! Say hello.";
+        }
+
+        country = country.trim();
+        boolean isKorean = country.equalsIgnoreCase("South Korea") || country.equalsIgnoreCase("KR");
+
+        if (isKorean) {
+            return "A new Korean friend has joined! Say hello.";
+        } else {
+            return String.format("A new friend from %s has joined!", country);
+        }
     }
 }

--- a/src/main/java/core/domain/notification/service/NotificationMessageGenerator.java
+++ b/src/main/java/core/domain/notification/service/NotificationMessageGenerator.java
@@ -33,7 +33,6 @@ public class NotificationMessageGenerator {
             case comment -> actorName + " replied to your comment.";
             case follow -> actorName + " accepted your follow request.";
             case receive -> actorName + " started following you.";
-            case newuser -> actorName + " just joined! Say hello!";
             case followuserpost -> actorName + " posted something new.";
             default -> "새로운 알림이 도착했습니다.";
         };

--- a/src/main/java/core/domain/notification/service/PushNotificationService.java
+++ b/src/main/java/core/domain/notification/service/PushNotificationService.java
@@ -121,11 +121,6 @@ public class PushNotificationService {
                             .putData("myId", String.valueOf(recipient.getId()))
                             .putData("roomName", roomName);
                     break;
-                case newuser:
-                    messageBuilder
-                            .putData("type", "newuser")
-                            .putData("userId", String.valueOf(event.referenceId()));
-                    break;
                 case followuserpost:
                     messageBuilder
                             .putData("type", "followuserpost")
@@ -174,20 +169,19 @@ public class PushNotificationService {
     }
     public void sendBatchPush(List<String> tokens, String title, String body, Long actorId) {
         if (tokens.isEmpty()) return;
-
         MulticastMessage message = MulticastMessage.builder()
                 .addAllTokens(tokens)
                 .setNotification(Notification.builder()
                         .setTitle(title)
                         .setBody(body)
                         .build())
+                .putData("notificationType", NotificationType.newuser.name())
                 .putData("type", "newuser")
                 .putData("userId", String.valueOf(actorId))
                 .build();
 
         try {
             BatchResponse response = firebaseMessaging.sendEachForMulticast(message);
-
             if (response.getFailureCount() > 0) {
                 log.warn("배치 발송 완료: 성공 {}, 실패 {}", response.getSuccessCount(), response.getFailureCount());
             }

--- a/src/main/java/core/domain/notification/service/PushNotificationService.java
+++ b/src/main/java/core/domain/notification/service/PushNotificationService.java
@@ -1,9 +1,6 @@
 package core.domain.notification.service;
 
-import com.google.firebase.messaging.FirebaseMessaging;
-import com.google.firebase.messaging.FirebaseMessagingException;
-import com.google.firebase.messaging.Message;
-import com.google.firebase.messaging.MessagingErrorCode;
+import com.google.firebase.messaging.*;
 import core.domain.chat.entity.ChatParticipant;
 import core.domain.chat.repository.ChatParticipantRepository;
 import core.domain.notification.dto.NotificationEvent;
@@ -33,6 +30,7 @@ public class PushNotificationService {
     private final UserNotificationSettingRepository userNotificationSettingRepository;
     private final ChatParticipantRepository chatParticipantRepository;
     private final NotificationMetrics notificationMetrics;
+
 
     /**
      * 사용자에게 푸시 알림을 발송합니다. (람다 제거 버전)
@@ -172,6 +170,29 @@ public class PushNotificationService {
 
                 throw e;
             }
+        }
+    }
+    public void sendBatchPush(List<String> tokens, String title, String body, Long actorId) {
+        if (tokens.isEmpty()) return;
+
+        MulticastMessage message = MulticastMessage.builder()
+                .addAllTokens(tokens)
+                .setNotification(Notification.builder()
+                        .setTitle(title)
+                        .setBody(body)
+                        .build())
+                .putData("type", "newuser")
+                .putData("userId", String.valueOf(actorId))
+                .build();
+
+        try {
+            BatchResponse response = firebaseMessaging.sendEachForMulticast(message);
+
+            if (response.getFailureCount() > 0) {
+                log.warn("배치 발송 완료: 성공 {}, 실패 {}", response.getSuccessCount(), response.getFailureCount());
+            }
+        } catch (FirebaseMessagingException e) {
+            log.error("FCM 배치 발송 중 오류 발생 토큰이 없는 유저", e);
         }
     }
 }

--- a/src/main/java/core/domain/user/controller/MyPageController.java
+++ b/src/main/java/core/domain/user/controller/MyPageController.java
@@ -141,23 +141,6 @@ public class MyPageController {
     }
 
 
-    /**
-     * todo : /profile/edit,profile/skip-setup가 어디서 쓰이는 불명확함 확인 후 스웨거 및 로직 수정해야함
-     * **/
-    @PatchMapping(value = "/profile/skip-setup", consumes = "application/json", produces = "application/json")
-    @Operation(
-            summary = "프로필 셋업 마무리",
-            description = "로그인 후 사용자가 하는 첫 프로필 셋업.사용자가 데이터를 다 넣는다면 USER로 ROLE을 가지고" +
-                    "한개라도 스킵을한다면 ROLE이 VISITOR가 됩니다."
-    )
-    @UserErrorDocs({UserErrorCode.USER_NOT_FOUND})
-    @ImageErrorCodeDocs({ImageErrorCode.IMAGE_UPLOAD_FAILED, ImageErrorCode.IMAGE_FILE_UPLOAD_TYPE_ERROR,  })
-    public ResponseEntity<ApiResponse<LoginResponseDto>> skipSetUpProfile(
-            @Valid @RequestBody UserUpdateDto dto
-    ) {
-        return ResponseEntity.ok(ApiResponse.success(userService.finalizeSkipSetupAndReissueToken(dto)));
-    }
-
     @PatchMapping(value = "/profile/edit", consumes = "application/json", produces = "application/json")
     @Operation(
             summary = "마이페이지 프로필 수정",

--- a/src/main/java/core/domain/user/repository/UserRepository.java
+++ b/src/main/java/core/domain/user/repository/UserRepository.java
@@ -189,16 +189,4 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
     Object[] visitorShareOverall();
 
 
-    /*
-            * 1. User 엔티티 전체를 가져오지 않고 'fcmToken'만 가져옵니다. (메모리 절약)
-            * 2. DB 인덱스를 활용해 '국가'와 '최근 접속일'로 필터링합니다. (속도 향상)
-            */
-    @Query("SELECT u.fcmToken FROM User u " +
-            "WHERE u.country = :targetCountry " +
-            "AND u.lastSeenAt >= :activeSince")
-    Slice<String> findActiveUserTokens(
-            @Param("targetCountry") String targetCountry,
-            @Param("activeSince") Instant activeSince,
-            Pageable pageable
-    );
 }

--- a/src/main/java/core/domain/user/repository/UserRepository.java
+++ b/src/main/java/core/domain/user/repository/UserRepository.java
@@ -2,6 +2,8 @@ package core.domain.user.repository;
 
 
 import core.domain.user.entity.User;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -185,4 +187,18 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
     FROM users
     """, nativeQuery = true)
     Object[] visitorShareOverall();
+
+
+    /*
+            * 1. User 엔티티 전체를 가져오지 않고 'fcmToken'만 가져옵니다. (메모리 절약)
+            * 2. DB 인덱스를 활용해 '국가'와 '최근 접속일'로 필터링합니다. (속도 향상)
+            */
+    @Query("SELECT u.fcmToken FROM User u " +
+            "WHERE u.country = :targetCountry " +
+            "AND u.lastSeenAt >= :activeSince")
+    Slice<String> findActiveUserTokens(
+            @Param("targetCountry") String targetCountry,
+            @Param("activeSince") Instant activeSince,
+            Pageable pageable
+    );
 }

--- a/src/main/java/core/domain/user/service/UserService.java
+++ b/src/main/java/core/domain/user/service/UserService.java
@@ -228,10 +228,28 @@ public class UserService {
         if (dto.imageKey() != null) {
             imageService.saveUserProfileImage(user.getId(), dto.imageKey());
         }
-
-        //publisher.publishEvent(new NewUserJoinedEvent(user.getId()));
+        if (isAllProfileFieldsFilled(dto)) {
+            publisher.publishEvent(new NewUserJoinedEvent(user.getId()));
+            log.info("모든 프로필 정보 입력 완료. 신규 유저 알림 이벤트 발행: UserID={}", user.getId());
+        } else {
+            log.info("일부 프로필 정보 누락으로 알림 미발행: {}", dto);
+        }
     }
-
+    /**
+     * DTO의 필수 필드가 모두 채워졌는지 검사하는 메서드
+     */
+    private boolean isAllProfileFieldsFilled(UserSetupRequest dto) {
+        return notBlank(dto.firstname()) &&
+                notBlank(dto.lastname()) &&
+                notBlank(dto.gender()) &&
+                notBlank(dto.birthday()) &&
+                notBlank(dto.country()) &&
+                notBlank(dto.introduction()) &&
+                notBlank(dto.purpose()) &&
+                notBlank(dto.imageKey()) && // 이미지도 필수
+                dto.language() != null && !dto.language().isEmpty() && // 언어도 1개 이상
+                dto.hobby() != null && !dto.hobby().isEmpty(); // 취미도 1개 이상
+    }
     private boolean notBlank(String s) {
         return s != null && !s.isBlank();
     }

--- a/src/main/java/core/domain/userdevicetoken/repository/UserDeviceTokenRepository.java
+++ b/src/main/java/core/domain/userdevicetoken/repository/UserDeviceTokenRepository.java
@@ -2,8 +2,14 @@ package core.domain.userdevicetoken.repository;
 
 import core.domain.user.entity.User;
 import core.domain.userdevicetoken.entity.UserDeviceToken;
+import core.global.enums.NotificationType;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -14,4 +20,27 @@ public interface UserDeviceTokenRepository extends JpaRepository<UserDeviceToken
     List<UserDeviceToken> findAllByUserId(Long id);
     void deleteAllByUserId(Long userId);
     List<UserDeviceToken> findAllByUser(User user);
+
+    /**
+     * 🚀 [최적화 쿼리]
+     * 1. Target: 'UserDeviceToken' 테이블 기준
+     * 2. Join: User(국가, 활동시간 확인용) + UserNotificationSetting(알림 수신 동의 확인용)
+     * 3. Filter: 한국인(KR) + 최근 7일 활동 + 알림 설정 ON
+     * 4. Select: 엔티티가 아닌 'deviceToken(String)'만 조회 (메모리 절약)
+     */
+    @Query("SELECT udt.deviceToken " +
+            "FROM UserDeviceToken udt " +
+            "JOIN udt.user u " +
+            "JOIN u.notificationSettings uns " +
+            "WHERE u.country IN :targetCountries " +  // 1. 타겟 국가 (한국)
+            "AND u.lastSeenAt >= :activeSince " +     // 2. 최근 활동 유저
+            "AND uns.notificationType = :type " +     // 3. 알림 타입 (NEW_USER)
+            "AND uns.enabled = true " +               // 4. 알림 켜둔 사람만
+            "AND udt.deviceToken IS NOT NULL")
+    Slice<String> findTokensForBroadcast(
+            @Param("targetCountries") List<String> targetCountries,
+            @Param("activeSince") Instant activeSince,
+            @Param("type") NotificationType type,
+            Pageable pageable
+    );
 }


### PR DESCRIPTION
# 📄 PR 변경사항
- **신규 유저 브로드캐스트 성능 최적화**: 기존 루프(Loop) 방식을 **배치(Batch) 발송**으로 변경하고, 불필요한 DB 저장 로직을 제거했습니다.
- **서버 기동 에러 수정**: `UserRepository` 내 존재하지 않는 필드(`fcmToken`)를 참조하던 잘못된 쿼리 메서드를 삭제하여 `UnsatisfiedDependencyException`을 해결했습니다.
- **레거시 코드 제거**: 배치 전환으로 인해 사용하지 않는 단건 발송 로직(`newuser` case)을 정리했습니다.

# 🖌️ 구체적인 구현 내용
- **DB 커넥션 점유 문제 해결**: `NotificationEventListener`에서 `@Transactional`을 제거하여, FCM 발송 대기 시간 동안 DB 커넥션을 점유(Holding)하던 문제를 해결했습니다. (HikariCP 누수 경고 해결)
- **메모리 최적화 (Projection)**: `User` 엔티티 전체를 로딩(`findAll`)하는 대신, `UserDeviceTokenRepository`를 통해 필요한 **Device Token(String)**만 조회하도록 쿼리를 변경했습니다.
- **배치 발송 적용**: FCM의 `sendEachForMulticast`를 사용하여 500건씩 묶어서 발송하도록 변경, 네트워크 오버헤드를 획기적으로 줄였습니다.
- **글로벌 알림 메시지**: 신규 유저 알림 문구를 국적 기반의 영문 메시지("A new friend from...")로 변경했습니다.

# ✨개선 사항 및 참고 사항
- **성능 향상**: 유저 900명 기준 발송 소요 시간이 **약 24초 → 1초 미만**으로 단축되었습니다.
- **참고**: 신규 유저 전체 알림(Broadcast)은 시스템 부하 방지를 위해 **알림 내역을 DB에 저장하지 않습니다.** (휘발성 푸시)

# 💯 테스트
- [x] **서버 기동 테스트**: `UserRepository` 쿼리 수정 후 Spring Context가 정상적으로 로드되는지 확인 완료.
- [x] **발송 테스트**: 신규 유저 프로필 셋업 완료 시, `handleNewUserBroadcastOptimized` 리스너가 동작하며 배치 발송 로그가 정상 출력되는지 확인.

# 확인
- [x] 주석 및 print를 제거하셨나요?
- [ ] javaDoc을 작성하셨나요?
- [x] merge할 브랜치와 로컬에서 merge 하셨나요?
- [x] 더 수정할 작업은 없는지 확인하셨나요?