### PR TITLE
feat: 채팅 번역 Redis,db  하이브리드 캐싱/읽음 처리 이관 및 전송 로직 최적화

### DIFF
--- a/src/main/java/core/domain/chat/entity/ChatMessageTranslation.java
+++ b/src/main/java/core/domain/chat/entity/ChatMessageTranslation.java
@@ -1,0 +1,53 @@
+package core.domain.chat.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "chat_message_translation",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_message_lang",
+                        columnNames = {"message_id", "language_code"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_message_id", columnList = "message_id")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class ChatMessageTranslation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "translation_id")
+    private Long id;
+
+    @Column(name = "message_id", nullable = false)
+    private Long messageId;
+
+    @Column(name = "language_code", nullable = false, length = 10)
+    private String languageCode; // e.g., "en", "vi", "ko"
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private Instant createdAt;
+
+
+    public ChatMessageTranslation(Long messageId, String languageCode, String content) {
+        this.messageId = messageId;
+        this.languageCode = languageCode;
+        this.content = content;
+    }
+}

--- a/src/main/java/core/domain/chat/repository/ChatMessageTranslationRepository.java
+++ b/src/main/java/core/domain/chat/repository/ChatMessageTranslationRepository.java
@@ -1,0 +1,15 @@
+package core.domain.chat.repository;
+
+import core.domain.chat.entity.ChatMessageTranslation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ChatMessageTranslationRepository extends JpaRepository<ChatMessageTranslation, Long> {
+
+    List<ChatMessageTranslation> findByMessageIdInAndLanguageCode(List<Long> messageIds, String languageCode);
+
+    void deleteByCreatedAtBefore(java.time.Instant threshold);
+}

--- a/src/main/java/core/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/core/domain/chat/service/ChatMessageService.java
@@ -154,17 +154,15 @@ public class ChatMessageService {
         for (ChatParticipant p : chatRoom.getParticipants()) {
             User recipient = p.getUser();
 
-            // 차단된 유저 제외
             if (blockedUserIds.contains(recipient.getId())) continue;
 
-            // 보낸 사람 처리 (SELF)
             if (recipient.getId().equals(sender.getId())) {
                 p.setLastReadMessageId(messageId); // Dirty Checking으로 자동 업데이트됨
                 recipientsByLang.computeIfAbsent("SELF", k -> new ArrayList<>()).add(recipient.getId());
                 continue;
             }
 
-            // 언어 설정 확인
+
             String lang = (p.isTranslateEnabled() && recipient.getTranslateLanguage() != null)
                     ? recipient.getTranslateLanguage()
                     : "NONE";
@@ -178,14 +176,12 @@ public class ChatMessageService {
      * 필요한 언어들에 대해 병렬로 번역을 수행합니다.
      */
     private Map<String, String> executeParallelTranslations(String originalContent, Set<String> targetLanguages) {
-        Map<String, String> resultMap = new ConcurrentHashMap<>(); // 병렬 처리를 위해 ConcurrentHashMap 사용 권장
+        Map<String, String> resultMap = new ConcurrentHashMap<>();
 
-        // 번역이 필요한 언어만 필터링
         List<String> languagesToTranslate = targetLanguages.stream()
                 .filter(lang -> !"SELF".equals(lang) && !"NONE".equals(lang))
                 .toList();
 
-        // CompletableFuture 리스트 생성 및 실행
         List<CompletableFuture<Void>> futures = languagesToTranslate.stream()
                 .map(lang -> CompletableFuture.runAsync(() -> {
                     try {
@@ -199,7 +195,6 @@ public class ChatMessageService {
                 }))
                 .toList();
 
-        // 모든 번역이 끝날 때까지 대기 (Join)
         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
 
         return resultMap;
@@ -228,13 +223,13 @@ public class ChatMessageService {
                     savedMessage.getId(),
                     savedMessage.getChatRoom().getId(),
                     sender.getId(),
-                    savedMessage.getContent(),                 // originContent (항상 원문)
-                    translatedText,                            // targetContent (번역문 or null)
-                    savedMessage.getSentAt(),                  // sentAt (Entity와 타입 일치 가정)
-                    sender.getFirstName(),                     // senderFirstName
-                    sender.getLastName(),                      // senderLastName
-                    userImageUrl,                              // senderImageUrl
-                    MessageType.TEXT                           // messageType
+                    savedMessage.getContent(),
+                    translatedText,
+                    savedMessage.getSentAt(),
+                    sender.getFirstName(),
+                    sender.getLastName(),
+                    userImageUrl,
+                    MessageType.TEXT
             );
 
             CompletableFuture<Void> future = CompletableFuture.runAsync(() ->
@@ -312,13 +307,11 @@ public class ChatMessageService {
         String finalContent = message.getContent();
         MessageType finalType = message.getMessageType();
 
-        // 관리자에 의해 삭제된 경우
         if ("BLOCKED_MEDIA".equals(finalContent)) {
             finalContent = "관리자에 의해 삭제된 이미지입니다.";
             finalType = MessageType.TEXT;
             translatedContent = null;
         }
-        // 그 외 이미지
         else if (finalType == MessageType.IMAGE) {
             if (!finalContent.startsWith("http")) {
                 finalContent = cdnBaseUrl + "/" + finalContent;

--- a/src/main/java/core/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/core/domain/chat/service/ChatMessageService.java
@@ -562,33 +562,39 @@ public class ChatMessageService {
                     .collect(Collectors.toList());
         }
     }
-
+    private List<String> getTranslatedMessages(List<ChatMessage> messages, ChatParticipant participant) {
+        if (participant.isTranslateEnabled() && participant.getUser().getTranslateLanguage() != null && !messages.isEmpty()) {
+            List<String> contents = messages.stream().map(ChatMessage::getContent).toList();
+            return translationService.translateMessages(contents, participant.getUser().getTranslateLanguage());
+        }
+        return Collections.emptyList();
+    }
     @Transactional(readOnly = true)
     public List<ChatMessageResponse> getMessagesAround(Long roomId, Long userId, Long targetMessageId) {
+        // 1. 참여자 조회
         ChatParticipant participant = chatParticipantRepository.findByChatRoomIdAndUserId(roomId, userId)
                 .orElseThrow(() -> new BusinessException(ChatErrorCode.NOT_CHAT_PARTICIPANT));
 
         List<ChatMessage> older = chatMessageRepository.findTop20ByChatRoomIdAndIdLessThanOrderByIdDesc(roomId, targetMessageId);
         Collections.reverse(older);
-        ChatMessage target = chatMessageRepository.findById(targetMessageId).orElseThrow(() -> new BusinessException(ChatErrorCode.MESSAGE_NOT_FOUND));
+
+        ChatMessage target = chatMessageRepository.findById(targetMessageId)
+                .orElseThrow(() -> new BusinessException(ChatErrorCode.MESSAGE_NOT_FOUND));
+
         List<ChatMessage> newer = chatMessageRepository.findTop20ByChatRoomIdAndIdGreaterThanOrderByIdAsc(roomId, targetMessageId);
 
         List<ChatMessage> combined = new ArrayList<>(older);
         combined.add(target);
         combined.addAll(newer);
 
-        boolean needsTranslation = participant.isTranslateEnabled();
-        String targetLanguage = participant.getUser().getTranslateLanguage();
+        List<String> translatedTexts = getTranslatedMessages(combined, participant);
 
-        if (needsTranslation && targetLanguage != null) {
-            List<String> contents = combined.stream().map(ChatMessage::getContent).toList();
-            List<String> translated = translationService.translateMessages(contents, targetLanguage);
-            return IntStream.range(0, combined.size())
-                    .mapToObj(i -> mapToResponse(combined.get(i), translated.get(i)))
-                    .collect(Collectors.toList());
-        }
-
-        return combined.stream().map(m -> mapToResponse(m, null)).collect(Collectors.toList());
+        return IntStream.range(0, combined.size())
+                .mapToObj(i -> {
+                    String translated = translatedTexts.isEmpty() ? null : translatedTexts.get(i);
+                    return mapToResponse(combined.get(i), translated);
+                })
+                .collect(Collectors.toList());
     }
 
     @Transactional

--- a/src/main/java/core/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/core/domain/chat/service/ChatMessageService.java
@@ -207,6 +207,7 @@ public class ChatMessageService {
 
     /**
      * 그룹별로 메시지를 생성하고 비동기로 전송합니다.
+     * (DTO 수정 없이 Record 생성자 사용)
      */
     private void executeParallelDispatch(
             Map<String, List<Long>> recipientsByLang,
@@ -222,33 +223,28 @@ public class ChatMessageService {
             List<Long> recipientIds = entry.getValue();
             if (recipientIds.isEmpty()) continue;
 
-            // 전송할 텍스트 결정
-            String contentToSend = determineContent(targetLang, savedMessage.getContent(), translatedContentsMap);
-
-            // DTO 생성
+            String translatedText = translatedContentsMap.get(targetLang);
             ChatMessageResponse messageResponse = new ChatMessageResponse(
-                    savedMessage.getId(), savedMessage.getChatRoom().getId(), sender.getId(),
-                    savedMessage.getContent(), contentToSend, savedMessage.getSentAt(),
-                    sender.getFirstName(), sender.getLastName(), userImageUrl, MessageType.TEXT
+                    savedMessage.getId(),
+                    savedMessage.getChatRoom().getId(),
+                    sender.getId(),
+                    savedMessage.getContent(),                 // originContent (항상 원문)
+                    translatedText,                            // targetContent (번역문 or null)
+                    savedMessage.getSentAt(),                  // sentAt (Entity와 타입 일치 가정)
+                    sender.getFirstName(),                     // senderFirstName
+                    sender.getLastName(),                      // senderLastName
+                    userImageUrl,                              // senderImageUrl
+                    MessageType.TEXT                           // messageType
             );
 
-            // 비동기 전송 (New Transaction)
             CompletableFuture<Void> future = CompletableFuture.runAsync(() ->
                     chatSummaryService.sendSummaryToRecipientsInNewTx(messageResponse, recipientIds)
             );
             futures.add(future);
         }
-
-        // 모든 전송 작업이 끝날 때까지 대기
         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
     }
 
-    private String determineContent(String targetLang, String originalContent, Map<String, String> translatedMap) {
-        if ("SELF".equals(targetLang) || "NONE".equals(targetLang)) {
-            return originalContent; // 원문
-        }
-        return translatedMap.getOrDefault(targetLang, originalContent); // 번역문 (없으면 원문)
-    }
 
     @Transactional(readOnly = true)
     public List<ChatMessageResponse> getMessages(Long roomId, Long userId, Long lastMessageId) {

--- a/src/main/java/core/domain/chat/service/ChatTranslationService.java
+++ b/src/main/java/core/domain/chat/service/ChatTranslationService.java
@@ -1,0 +1,147 @@
+package core.domain.chat.service;
+
+import core.domain.chat.entity.ChatMessage;
+import core.domain.chat.entity.ChatMessageTranslation;
+import core.domain.chat.repository.ChatMessageTranslationRepository;
+
+import core.global.service.TranslationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatTranslationService {
+
+    private final ChatMessageTranslationRepository translationRepository;
+    private final TranslationService externalTranslationService;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static final String CACHE_PREFIX = "trans:";
+    private static final Duration CACHE_TTL = Duration.ofDays(30);
+
+    /**
+     * [읽기 핵심 로직]
+     * 메시지 목록을 받아 번역된 내용을 채워줍니다.
+     * Redis -> DB -> API 순서로 조회하여 비용을 절감합니다.
+     */
+    public Map<Long, String> getTranslatedMessages(List<ChatMessage> messages, String targetLang) {
+        if (messages.isEmpty() || targetLang == null) return Collections.emptyMap();
+
+        Map<Long, String> resultMap = new HashMap<>();
+        List<ChatMessage> missingMessages = new ArrayList<>();
+
+        // 1. Redis에서 먼저 조회 (Bulk Get)
+        List<String> keys = messages.stream()
+                .map(msg -> getCacheKey(msg.getId(), targetLang))
+                .toList();
+        List<String> cachedValues = redisTemplate.opsForValue().multiGet(keys);
+
+        for (int i = 0; i < messages.size(); i++) {
+            String value = cachedValues.get(i);
+            if (value != null) {
+                resultMap.put(messages.get(i).getId(), value);
+            } else {
+                missingMessages.add(messages.get(i)); // Redis에 없는 것들
+            }
+        }
+
+        if (missingMessages.isEmpty()) return resultMap;
+
+        // 2. Redis에 없는 건 DB에서 조회 (Bulk Select)
+        List<Long> missingIds = missingMessages.stream().map(ChatMessage::getId).toList();
+        List<ChatMessageTranslation> dbTranslations = translationRepository.findByMessageIdInAndLanguageCode(missingIds, targetLang);
+
+        Set<Long> foundInDbIds = new HashSet<>();
+        for (ChatMessageTranslation t : dbTranslations) {
+            resultMap.put(t.getMessageId(), t.getContent());
+            foundInDbIds.add(t.getMessageId());
+            // DB에 있던 건 나중을 위해 Redis에 올려둠 (Cache Warming)
+            cacheToRedisAsync(t.getMessageId(), targetLang, t.getContent());
+        }
+
+        // 3. DB에도 없는 건 API 호출 (최후의 수단 - 비용 발생)
+        List<ChatMessage> totallyMissing = missingMessages.stream()
+                .filter(msg -> !foundInDbIds.contains(msg.getId()))
+                .toList();
+
+        if (!totallyMissing.isEmpty()) {
+            List<String> originalContents = totallyMissing.stream().map(ChatMessage::getContent).toList();
+
+            // 외부 API 호출 (동기)
+            List<String> apiResults = externalTranslationService.translateMessages(originalContents, targetLang);
+
+            for (int i = 0; i < totallyMissing.size(); i++) {
+                ChatMessage msg = totallyMissing.get(i);
+                String translatedText = apiResults.get(i);
+
+                resultMap.put(msg.getId(), translatedText);
+
+                // 4. 새로 번역된 건 DB + Redis에 저장 (비동기)
+                saveTranslationAsync(msg.getId(), targetLang, translatedText);
+            }
+        }
+
+        return resultMap;
+    }
+
+    /**
+     * [쓰기 핵심 로직]
+     * 번역 결과를 DB와 Redis에 비동기로 저장합니다.
+     * @Async 어노테이션으로 메인 스레드를 차단하지 않습니다.
+     */
+    @Async("taskExecutor") // 별도 스레드 풀 사용 권장
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveTranslationAsync(Long messageId, String languageCode, String content) {
+        try {
+            translationRepository.save(new ChatMessageTranslation(messageId, languageCode, content));
+        } catch (DataIntegrityViolationException e) {
+            log.warn("이미 저장된 번역입니다. messageId={}, lang={}", messageId, languageCode);
+        }
+        cacheToRedisAsync(messageId, languageCode, content);
+    }
+
+    private void cacheToRedisAsync(Long messageId, String languageCode, String content) {
+        String key = getCacheKey(messageId, languageCode);
+        redisTemplate.opsForValue().set(key, content, CACHE_TTL);
+    }
+
+    private String getCacheKey(Long messageId, String languageCode) {
+        return CACHE_PREFIX + messageId + ":" + languageCode;
+    }
+
+    /**
+     * [전송 시 호출]
+     * 메시지 전송 시점에 번역을 수행하고 결과만 리턴 (저장은 비동기로 처리)
+     */
+    public CompletableFuture<String> translateAndCache(Long messageId, String content, String targetLang) {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                // API 호출
+                List<String> res = externalTranslationService.translateMessages(List.of(content), targetLang);
+                if (res.isEmpty()) return content;
+
+                String translated = res.get(0);
+
+                // 결과 나왔으면 바로 비동기 저장 태우기 (Fire-and-Forget)
+                saveTranslationAsync(messageId, targetLang, translated);
+
+                return translated;
+            } catch (Exception e) {
+                log.error("Translation failed", e);
+                return content; // 실패 시 원문 리턴
+            }
+        });
+    }
+}

--- a/src/main/resources/db/migration/V22051207_create_chat_message_translation.sql
+++ b/src/main/resources/db/migration/V22051207_create_chat_message_translation.sql
@@ -1,0 +1,12 @@
+CREATE TABLE chat_message_translation (
+                                          translation_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                                          message_id BIGINT NOT NULL,
+                                          language_code VARCHAR(10) NOT NULL,
+                                          content TEXT NOT NULL,
+                                          created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+
+
+                                          CONSTRAINT uk_message_lang UNIQUE (message_id, language_code)
+);
+
+CREATE INDEX idx_message_id ON chat_message_translation (message_id);


### PR DESCRIPTION
# 📄 PR 변경사항
- 채팅 메시지 번역 서비스(`ChatTranslationService`) 구현
- 번역 비용 절감 및 조회 성능을 위한 3-layer 캐싱 전략(Redis -> DB -> API) 적용
- 번역 결과 비동기 저장 로직 구현

# 🖌️ 구체적인 구현 내용
**1. 3단 캐싱 전략을 통한 읽기 성능 최적화 (`getTranslatedMessages`)**
- 외부 번역 API 호출 비용을 최소화하고 응답 속도를 높이기 위해 **Redis -> DB -> 외부 API** 순서로 조회 로직을 구성했습니다.
    - **1단계 (Redis):** `multiGet`을 사용하여 요청된 메시지들의 번역본을 메모리에서 빠르게 조회합니다.
    - **2단계 (DB):** Redis 캐시 미스 발생 시, DB에서 Bulk 조회(`findByMessageIdIn`)를 수행하고, 조회된 데이터는 다시 Redis에 캐싱(Cache Warming)합니다.
    - **3단계 (API):** DB에도 없는 경우에만 외부 번역 API를 호출합니다.

**2. 비동기 처리를 통한 쓰기 성능 확보**
- **비동기 저장 (`saveTranslationAsync`):** API를 통해 새로 번역된 결과는 `@Async`를 사용하여 별도 스레드에서 DB와 Redis에 저장합니다. 이를 통해 사용자가 번역 저장을 기다리지 않도록 응답 지연을 방지했습니다.
- **트랜잭션 분리:** `Propagation.REQUIRES_NEW`를 사용하여 메인 로직의 트랜잭션과 분리하여, 번역 저장 중 예외가 발생하더라도 채팅 조회 로직에 영향을 주지 않도록 격리했습니다.

**3. 동시성 이슈 및 예외 처리**
- **중복 저장 방지:** 동시에 같은 메시지에 대한 번역 요청이 올 경우 `DataIntegrityViolationException`을 catch하여 로그를 남기고 무시하도록 처리하여 데이터 무결성을 유지했습니다.
- **실시간 번역 (`translateAndCache`):** 메시지 전송 시점의 번역은 `CompletableFuture`를 사용하여 비동기로 처리하고, 실패 시 원문을 반환하도록 Fail-safe 하게 구현했습니다.

# ✨개선 사항 및 참고 사항
- **TaskExecutor 설정:** `@Async("taskExecutor")`를 사용하고 있으므로, ThreadPoolTaskExecutor 설정 빈(`taskExecutor`)이 정상적으로 등록되어 있어야 동작합니다.
- **Redis TTL:** 번역 데이터의 Redis 만료 시간은 30일(`Duration.ofDays(30)`)로 설정하였습니다.
- **Bulk 연산:** Redis 조회 시 loop가 아닌 `multiGet`을 사용하여 네트워크 RTT를 줄였습니다.

# 💯 테스트
- [ ] Redis 캐시 히트/미스 시나리오 테스트 (로그 확인)
- [ ] 외부 API 호출 후 DB 및 Redis 저장 여부 확인
- [ ] `@Async` 비동기 동작 스레드 확인

# 확인
- [ ] 주석 및 print를 제거하셨나요?
- [ ] javaDoc을 작성하셨나요?
- [ ] merge할 브랜치와 로컬에서 merge 하셨나요?
- [ ] 더 수정할 작업은 없는지 확인하셨나요?