### PR TITLE
Bugfix/411 crawler ncp 이미지 저장 수정

### DIFF
--- a/src/main/java/core/global/entity/image/service/PostImageService.java
+++ b/src/main/java/core/global/entity/image/service/PostImageService.java
@@ -21,4 +21,6 @@ public interface PostImageService {
 
     @Transactional
     void uploadAndSavePostImages(Post post, List<MultipartFile> multipartFiles) throws IOException;
+
+    void uploadAndSavePostImagesFromUrls(Post post, List<String> imageUrls);
 }

--- a/src/main/java/core/global/entity/image/service/impl/PostImageServiceImpl.java
+++ b/src/main/java/core/global/entity/image/service/impl/PostImageServiceImpl.java
@@ -260,6 +260,77 @@ public class PostImageServiceImpl implements PostImageService {
         publishModerationEvents(savedImages);
     }
 
+    @Override
+    @Transactional
+    public void uploadAndSavePostImagesFromUrls(Post post, List<String> imageUrls) {
+        if (imageUrls == null || imageUrls.isEmpty()) return;
+
+        List<Image> newImages = new ArrayList<>();
+        int orderIndex = 0;
+
+        for (String originalUrl : imageUrls) {
+            try {
+
+                String s3Key = "posts/" + post.getId() + "/" + UUID.randomUUID() + getExtension(originalUrl);
+                uploadFileFromUrl(originalUrl, s3Key);
+                String finalUrl = UrlUtil.buildPublicUrlFromKey(endPoint, bucket, s3Key);
+
+                Image image = Image.of(
+                        ImageType.POST,
+                        post.getId(),
+                        finalUrl,
+                        orderIndex++,
+                        ImageModerationStatus.CLEAN,
+                        null
+                );
+                newImages.add(image);
+
+            } catch (Exception e) {
+                log.error("외부 이미지 업로드 실패 (건너뜀): {}", originalUrl, e);
+            }
+        }
+
+        List<Image> savedImages = imageRepository.saveAll(newImages);
+    }
+
+    private void uploadFileFromUrl(String urlString, String key) throws IOException {
+        java.net.URL url = new java.net.URL(urlString);
+        java.net.URLConnection connection = url.openConnection();
+        connection.setConnectTimeout(5000);
+        connection.setReadTimeout(5000);
+
+        try (java.io.InputStream inputStream = connection.getInputStream()) {
+            String contentType = connection.getContentType();
+            if (contentType == null) contentType = "image/jpeg";
+
+            long length = connection.getContentLengthLong();
+
+            PutObjectRequest.Builder reqBuilder = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .contentType(contentType)
+                    .acl(software.amazon.awssdk.services.s3.model.ObjectCannedACL.PUBLIC_READ);
+
+            if (length > 0) {
+                s3Client.putObject(reqBuilder.build(),
+                        software.amazon.awssdk.core.sync.RequestBody.fromInputStream(inputStream, length));
+            } else {
+                byte[] bytes = inputStream.readAllBytes();
+                s3Client.putObject(reqBuilder.build(),
+                        software.amazon.awssdk.core.sync.RequestBody.fromBytes(bytes));
+            }
+        }
+    }
+
+    private String getExtension(String url) {
+        if (url.contains(".")) {
+            String ext = url.substring(url.lastIndexOf("."));
+            if (ext.contains("?")) ext = ext.substring(0, ext.indexOf("?"));
+            if (ext.length() <= 5) return ext;
+        }
+        return ".jpg";
+    }
+
     private void publishModerationEvents(List<Image> savedImages) {
         for (Image img : savedImages) {
             String key = UrlUtil.toKeyFromUrlOrKey(endPoint, bucket, cdnBaseUrl, img.getUrl());

--- a/src/main/java/core/global/service/CrawledDataAdminService.java
+++ b/src/main/java/core/global/service/CrawledDataAdminService.java
@@ -12,6 +12,7 @@ import core.domain.user.repository.UserRepository;
 import core.global.config.CustomUserDetails;
 import core.global.entity.image.entity.Image;
 import core.global.entity.image.repository.ImageRepository;
+import core.global.entity.image.service.PostImageService;
 import core.global.enums.CrawledDataStatus;
 import core.global.enums.ImageType;
 import core.global.enums.errorcode.CommunityErrorCode;
@@ -36,6 +37,7 @@ public class CrawledDataAdminService {
     private final ImageRepository imageRepository;
     private final UserRepository userRepository;
     private final BoardRepository boardRepository;
+    private final PostImageService postImageService;
 
     @Transactional(readOnly = true)
     public Page<CrawledDataDto> getPendingCrawledData(Pageable pageable) {
@@ -71,9 +73,7 @@ public class CrawledDataAdminService {
                     ? selectedImageUrls.subList(0, 5)
                     : selectedImageUrls;
 
-            IntStream.range(0, finalImages.size())
-                    .mapToObj(i -> Image.of(ImageType.POST, savedPost.getId(), finalImages.get(i), i))
-                    .forEach(imageRepository::save);
+            postImageService.uploadAndSavePostImagesFromUrls(savedPost, finalImages);
         }
 
         crawledData.updateStatus(CrawledDataStatus.APPROVED, savedPost.getId());


### PR DESCRIPTION
# 📄 PR 변경사항
- 관리자 페이지에서 크롤링 게시글 올릴 시 사진이 ncp서버에 저장되도록 수정

# 🖌️ 구체적인 구현 내용
<!--  어떤 점을 고려하여 구현하였는지, 어떤 예외를 던지는지 등의 내용을 알려주세요! -->
-

# ✨개선 사항 및 참고 사항
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 


# 💯 테스트
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 

# 확인
- [ ] 주석 및 print를 제거하셨나요?
- [ ] javaDoc을 작성하셨나요?
- [ ] merge할 브랜치와 로컬에서 merge 하셨나요?
- [ ] 더 수정할 작업은 없는지 확인하셨나요?
