### PR TITLE
Bugfix/414 admin image ncp deletion

### DIFF
--- a/src/main/java/core/global/entity/image/service/impl/PostImageServiceImpl.java
+++ b/src/main/java/core/global/entity/image/service/impl/PostImageServiceImpl.java
@@ -230,7 +230,7 @@ public class PostImageServiceImpl implements PostImageService {
                 extension = originalFileName.substring(originalFileName.lastIndexOf("."));
             }
             String uniqueFileName = UUID.randomUUID() + extension;
-            String s3Key = "post-images/" + post.getId() + "/" + uniqueFileName;
+            String s3Key = "posts/" + post.getId() + "/" + uniqueFileName;
 
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                     .bucket(s3Props.getBucket())

--- a/src/main/java/core/global/service/AdminImageService.java
+++ b/src/main/java/core/global/service/AdminImageService.java
@@ -68,10 +68,14 @@ public class AdminImageService {
     }
 
     private String extractKeyFromUrl(String url) {
-        String prefix = s3Props.getEndPoint() + "/" + s3Props.getBucket() + "/";
-        if (url.startsWith(prefix)) {
-            return url.replace(prefix, "");
+        String splitToken = "/" + s3Props.getBucket() + "/";
+        int index = url.indexOf(splitToken);
+
+        if (index != -1) {
+            return url.substring(index + splitToken.length());
         }
+
+        log.warn("S3 Key extraction failed. URL: {}, Bucket: {}", url, s3Props.getBucket());
         return null;
     }
 }


### PR DESCRIPTION
# 📄 PR 변경사항
- 관리자 유해 이미지 삭제 시 NCP 스토리지 원본 파일 미삭제 문제 수정

# 🖌️ 구체적인 구현 내용
<!--  어떤 점을 고려하여 구현하였는지, 어떤 예외를 던지는지 등의 내용을 알려주세요! -->
- URL 내부의 버킷 명을 기준으로 파싱하여 S3 Key를 추출하도록 변경

# ✨개선 사항 및 참고 사항
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 


# 💯 테스트
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 

# 확인
- [ ] 주석 및 print를 제거하셨나요?
- [ ] javaDoc을 작성하셨나요?
- [ ] merge할 브랜치와 로컬에서 merge 하셨나요?
- [ ] 더 수정할 작업은 없는지 확인하셨나요?
