### PR TITLE
Refator/oauth login

### DIFF
--- a/src/main/java/core/domain/notification/service/PushNotificationService.java
+++ b/src/main/java/core/domain/notification/service/PushNotificationService.java
@@ -30,17 +30,12 @@ public class PushNotificationService {
     private final ChatParticipantRepository chatParticipantRepository;
     private final NotificationMetrics notificationMetrics;
 
-
     /**
-     * 사용자에게 푸시 알림을 발송합니다. (람다 제거 버전)
-     * 발송 전 3단계 동의 여부를 모두 확인합니다.
-     * 클라이언트 이동을 위한 data 페이로드를 포함합니다.
-     * @param event 알림 이벤트 데이터
-     * @param message 사용자에게 보여줄 최종 메시지
+     * 사용자에게 푸시 알림을 발송합니다.
+     * SENDER_ID_MISMATCH 발생 시 로그 없이 토큰을 삭제합니다.
      */
     @Transactional
     public void sendPushNotification(User recipient, NotificationEvent event, String message) throws FirebaseMessagingException {
-
 
         if (!recipient.isAgreedToPushNotification()) {
             log.info("사용자 ID {}: 마스터 스위치 OFF. 푸시 알림을 발송하지 않습니다.", recipient.getId());
@@ -133,38 +128,52 @@ public class PushNotificationService {
 
             try {
                 firebaseMessaging.send(fcmMessage);
-                log.info("사용자 ID {} 에게 푸시 알림을 성공적으로 발송했습니다. (기기 토큰: ...{})", recipient.getId(), userDeviceToken.getDeviceToken().substring(userDeviceToken.getDeviceToken().length() - 5));
+                log.info("사용자 ID {} 에게 푸시 알림을 성공적으로 발송했습니다. (기기 토큰: ...{})", recipient.getId(), userDeviceToken.getDeviceToken().substring(Math.max(0, userDeviceToken.getDeviceToken().length() - 5)));
 
                 notificationMetrics.mark("push", "sent", "ok");
                 notificationMetrics.recordSend("push", "firebase", start);
+
             } catch (FirebaseMessagingException e) {
                 MessagingErrorCode code = e.getMessagingErrorCode();
                 String errorMessage = e.getMessage();
-
                 String reason = "unknown";
 
-                if (code == MessagingErrorCode.UNREGISTERED ||
-                    (code == MessagingErrorCode.INVALID_ARGUMENT && errorMessage != null && errorMessage.contains("registration token")) ||
-                    code == MessagingErrorCode.SENDER_ID_MISMATCH) {
+                if (code == MessagingErrorCode.SENDER_ID_MISMATCH) {
+                    userDeviceTokenRepository.delete(userDeviceToken);
+                    reason = "invalid_token_mismatch";
+                    // 로그 생략 (원한다면 debug 레벨로 추가 가능)
+                }
+                else if (code == MessagingErrorCode.UNREGISTERED ||
+                        (code == MessagingErrorCode.INVALID_ARGUMENT && errorMessage != null && errorMessage.contains("registration token"))) {
                     log.info("만료/무효 토큰 삭제: {} (코드: {})", userDeviceToken.getDeviceToken(), code);
                     userDeviceTokenRepository.delete(userDeviceToken);
                     reason = "invalid_token";
-                } else if (code == MessagingErrorCode.QUOTA_EXCEEDED ||
-                           code == MessagingErrorCode.UNAVAILABLE ||
-                           code == MessagingErrorCode.INTERNAL) {
+                }
+                // 재시도 필요
+                else if (code == MessagingErrorCode.QUOTA_EXCEEDED ||
+                        code == MessagingErrorCode.UNAVAILABLE ||
+                        code == MessagingErrorCode.INTERNAL) {
                     log.warn("재시도 필요: {} (코드: {})", errorMessage, code);
                     reason = "retryable";
-                } else {
+                }
+                // 기타 에러
+                else {
                     log.error("기타 FCM 에러: {} (코드: {})", errorMessage, code, e);
                 }
 
                 notificationMetrics.mark("push", "failed", reason);
                 notificationMetrics.recordSend("push", "firebase", start);
 
-                throw e;
+                // Sender ID Mismatch가 아닐 때만 예외를 던짐 (로직 흐름 유지)
+                if (code != MessagingErrorCode.SENDER_ID_MISMATCH &&
+                        code != MessagingErrorCode.UNREGISTERED &&
+                        code != MessagingErrorCode.INVALID_ARGUMENT) {
+                    throw e;
+                }
             }
         }
     }
+
     @Transactional
     public void sendBatchPush(List<String> tokens, String title, String body, Long actorId) {
         if (tokens == null || tokens.isEmpty()) return;
@@ -196,22 +205,27 @@ public class PushNotificationService {
                         MessagingErrorCode code = e.getMessagingErrorCode();
                         String errorMessage = e.getMessage();
 
-                        if (code == MessagingErrorCode.UNREGISTERED ||
-                                code == MessagingErrorCode.SENDER_ID_MISMATCH ||
+                        if (code == MessagingErrorCode.SENDER_ID_MISMATCH) {
+                            tokensToDelete.add(failedToken);
+                            notificationMetrics.mark("push_batch", "failed", "invalid_token_mismatch");
+                        }
+                        // 기존 만료 토큰 로그
+                        else if (code == MessagingErrorCode.UNREGISTERED ||
                                 (code == MessagingErrorCode.INVALID_ARGUMENT && errorMessage != null && errorMessage.contains("registration token"))) {
 
                             log.warn("🚨 만료/무효 토큰 감지 -> 삭제 예정: {} (코드: {})", failedToken, code);
                             tokensToDelete.add(failedToken);
-
                             notificationMetrics.mark("push_batch", "failed", "invalid_token");
 
                         }
+                        // 일시적 장애
                         else if (code == MessagingErrorCode.QUOTA_EXCEEDED ||
                                 code == MessagingErrorCode.UNAVAILABLE ||
                                 code == MessagingErrorCode.INTERNAL) {
                             log.warn("⚠️ FCM 서버 일시적 장애 (재시도 권장): {} (코드: {})", failedToken, code);
                             notificationMetrics.mark("push_batch", "failed", "retryable");
                         }
+                        // 기타 에러
                         else {
                             log.error("❌ 기타 배치 발송 실패: {} (코드: {}, 에러: {})", failedToken, code, errorMessage);
                             notificationMetrics.mark("push_batch", "failed", "unknown");
@@ -223,7 +237,8 @@ public class PushNotificationService {
 
                 if (!tokensToDelete.isEmpty()) {
                     userDeviceTokenRepository.deleteByDeviceTokenIn(tokensToDelete);
-                    log.info("🧹 총 {}개의 만료된 토큰을 DB에서 정리했습니다.", tokensToDelete.size());
+                    // 삭제 완료 사실만 가볍게 INFO로 남김
+                    log.info("🧹 만료 및 프로젝트 불일치 토큰 {}개 정리 완료.", tokensToDelete.size());
                 }
             }
 
@@ -235,15 +250,13 @@ public class PushNotificationService {
             notificationMetrics.mark("push_batch", "error", "exception");
         }
     }
+
     /**
      * [New] 채팅방 대량 알림 발송 (Listener에서 호출)
-     * - 기존 sendPushNotification의 'chat' 케이스와 동일한 데이터 구조를 가집니다.
-     * - 500개씩 끊어서 FCM에 던집니다.
      */
     @Transactional
     public void sendGroupPush(List<Long> recipientIds, String messageBody, String roomId, String roomName, Long senderId) {
         if (recipientIds == null || recipientIds.isEmpty()) return;
-
 
         List<UserDeviceToken> tokens = userDeviceTokenRepository.findAllByUserIdIn(recipientIds);
 
@@ -260,7 +273,6 @@ public class PushNotificationService {
         data.put("roomId", roomId);
         data.put("roomName", roomName != null ? roomName : "Chat Room");
         data.put("senderId", String.valueOf(senderId));
-
 
         List<List<String>> partitions = new ArrayList<>();
         int batchSize = 500;
@@ -289,9 +301,10 @@ public class PushNotificationService {
                         if (!responses.get(i).isSuccessful()) {
                             FirebaseMessagingException e = responses.get(i).getException();
                             MessagingErrorCode code = e.getMessagingErrorCode();
-
-                            if (code == MessagingErrorCode.UNREGISTERED ||
-                                    code == MessagingErrorCode.SENDER_ID_MISMATCH ||
+                            if (code == MessagingErrorCode.SENDER_ID_MISMATCH) {
+                                tokensToDelete.add(batchTokens.get(i));
+                            }
+                            else if (code == MessagingErrorCode.UNREGISTERED ||
                                     code == MessagingErrorCode.INVALID_ARGUMENT) {
                                 tokensToDelete.add(batchTokens.get(i));
                             }
@@ -300,7 +313,6 @@ public class PushNotificationService {
 
                     if (!tokensToDelete.isEmpty()) {
                         userDeviceTokenRepository.deleteByDeviceTokenIn(tokensToDelete);
-                        log.info("🧹 Bulk Cleanup: 만료된 토큰 {}개 삭제 완료", tokensToDelete.size());
                     }
                 }
 
@@ -311,5 +323,5 @@ public class PushNotificationService {
                 notificationMetrics.mark("push_batch", "error", "exception");
             }
         }
-}
+    }
 }

--- a/src/main/java/core/domain/user/controller/LoginRegisterController.java
+++ b/src/main/java/core/domain/user/controller/LoginRegisterController.java
@@ -87,57 +87,17 @@ public class LoginRegisterController {
     @Operation(summary = "로그아웃 API", description = "현재 사용자의 액세스 토큰을 블랙리스트에 등록하고, 리프레시 토큰을 삭제합니다.")
     public ResponseEntity<Void> logout(HttpServletRequest request) {
         String authHeader = request.getHeader("Authorization");
-        String accessToken = authHeader.substring(7);
-        long expiration = jwtTokenProvider.getExpiration(accessToken).getTime() - System.currentTimeMillis();
-
-        redisService.blacklistAccessToken(accessToken, expiration);
-
-        Long userId = jwtTokenProvider.getUserIdFromAccessToken(accessToken);
-        redisService.deleteRefreshToken(userId);
-
-        log.info("사용자 {} 로그아웃 처리 완료.", userId);
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String accessToken = authHeader.substring(7);
+            userService.logout(accessToken);
+        }
         return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/refresh")
     @Operation(summary = "토큰 재발급 API", description = "리프레시 토큰으로 새로운 액세스 토큰과 리프레시 토큰을 발급합니다.")
     public ResponseEntity<ApiResponse<TokenRefreshResponse>> refreshToken(@RequestBody TokenRefreshRequest request) {
-        log.info("--- [토큰 재발급] 요청 수신 ---");
-        String refreshToken = request.refreshToken();
-        if (!jwtTokenProvider.validateToken(refreshToken)) {
-            log.warn("유효하지 않은 리프레시 토큰 요청: {}", refreshToken);
-            return new ResponseEntity<>(ApiResponse.fail("Invalid or expired refresh token"), HttpStatus.UNAUTHORIZED);
-        }
-
-        Long UserId = jwtTokenProvider.getUserIdFromRefreshToken(refreshToken);
-        Optional<User> userOptional = userrepository.getUserById(UserId);
-
-        if (userOptional.isEmpty()) {
-            log.error("토큰의 ID({})로 사용자를 찾을 수 없음", UserId);
-            return new ResponseEntity<>(ApiResponse.fail("User not found"), HttpStatus.NOT_FOUND);
-        }
-
-        User user = userOptional.get();
-
-        String storedRefreshToken = redisService.getRefreshToken(user.getId());
-        log.warn("사용자의 요청한 리프레쉬 토큰 : {}", refreshToken);
-        log.warn("레디스의 요청한 리프레쉬 토큰 : {}", storedRefreshToken);
-        if (storedRefreshToken == null || !storedRefreshToken.equals(refreshToken)) {
-            log.warn("Redis의 리프레시 토큰과 불일치. 탈취 가능성. 사용자 ID: {}", user.getId());
-            redisService.deleteRefreshToken(user.getId());
-            return new ResponseEntity<>(ApiResponse.fail("Refresh token mismatch or blacklisted"), HttpStatus.UNAUTHORIZED);
-        }
-        redisService.deleteRefreshToken(user.getId());
-        String newAccessToken = jwtTokenProvider.createAccessToken(user.getId(), user.getUserRole().toString(), user.getEmail());
-        String newRefreshToken = jwtTokenProvider.createRefreshToken(user.getId());
-
-        Date expirationDate = jwtTokenProvider.getExpiration(newRefreshToken);
-        long expirationMillis = expirationDate.getTime() - System.currentTimeMillis();
-        redisService.saveRefreshToken(user.getId(), newRefreshToken, expirationMillis);
-
-        log.info("--- [토큰 재발급] 완료. 사용자 ID: {} ---", user.getId());
-
-        TokenRefreshResponse responseDto = new TokenRefreshResponse(newAccessToken, newRefreshToken, user.getId());
+        TokenRefreshResponse responseDto = userService.refreshTokens(request.refreshToken());
         return ResponseEntity.ok(ApiResponse.success(responseDto));
     }
 

--- a/src/main/java/core/domain/user/controller/LoginRegisterController.java
+++ b/src/main/java/core/domain/user/controller/LoginRegisterController.java
@@ -81,8 +81,9 @@ public class LoginRegisterController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "구글 소셜 로그인", description = "앱에서 받은 인증 코드로 구글 로그인을 처리하고 JWT를 발급합니다.")
+    @Operation(summary = "구글 소셜 로그인,회원가입", description = "앱에서 받은 인증 코드로 구글 로그인을 처리하고 JWT를 발급합니다.")
     @PostMapping("/google/app-login")
+    @UserErrorDocs({UserErrorCode.DUPLICATE_EMAIL_PROVIDER_MISMATCH,})
     public ResponseEntity<ApiResponse<LoginResponseDto>> googleLogin(@RequestBody GoogleLoginReq req) {
         LoginResponseDto responseDto = googleAuthService.processGoogleLogin(req.getCode());
         return ResponseEntity.ok(ApiResponse.success(responseDto));
@@ -99,23 +100,16 @@ public class LoginRegisterController {
         }
         return ResponseEntity.noContent().build();
     }
-    @Operation(summary = "애플 소셜 로그인", description = "앱에서 받은 identityToken으로 애플 로그인을 처리하고 JWT를 발급합니다.")
+    @Operation(summary = "애플 소셜 로그인 및 회원가입", description = "앱에서 받은 identityToken으로 애플 로그인을 처리하고 JWT를 발급합니다.")
     @PostMapping("/apple/app-login")
     @AuthErrorDocs({AuthErrorCode.INVALID_APPLE_REQUEST})
+    @UserErrorDocs({UserErrorCode.DUPLICATE_RESOURCE, UserErrorCode.DUPLICATE_EMAIL_PROVIDER_MISMATCH}) // 에러 문서화
     public ResponseEntity<ApiResponse<LoginResponseDto>> loginWithApple(
             @Parameter(description = "Apple 로그인 요청 데이터", required = true)
             @RequestBody @Valid AppleLoginByCodeRequest req) {
-
-        try {
-            LoginResponseDto responseDto = appleAuthService.login(req);
-            publisher.publishEvent(new UserLoggedInEvent(responseDto.userId().toString(), "apple"));
-            return ResponseEntity.ok(ApiResponse.success(responseDto));
-
-        } catch (Exception e) {
-            log.error("--- [Apple 앱 로그인] 로그인 처리 중 오류 발생 ---", e);
-            ApiResponse<LoginResponseDto> errorResponse = ApiResponse.fail("로그인 실패: " + e.getMessage());
-            return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
-        }
+        LoginResponseDto responseDto = appleAuthService.login(req);
+        publisher.publishEvent(new UserLoggedInEvent(responseDto.userId().toString(), "apple"));
+        return ResponseEntity.ok(ApiResponse.success(responseDto));
     }
 
     @PostMapping("/refresh")

--- a/src/main/java/core/domain/user/controller/LoginRegisterController.java
+++ b/src/main/java/core/domain/user/controller/LoginRegisterController.java
@@ -59,9 +59,6 @@ import java.util.Optional;
 @Slf4j
 public class LoginRegisterController {
     private final UserService userService;
-    private final JwtTokenProvider jwtTokenProvider;
-    private final RedisService redisService;
-    private final UserRepository userrepository;
     private final PasswordService passwordService;
     private final AppleAuthService appleAuthService;
     private final ApplicationEventPublisher publisher;
@@ -75,6 +72,13 @@ public class LoginRegisterController {
                                     @RequestParam(required = false) String state) {
         return "Received code: " + code + ", state: " + state;
     }
+    @PostMapping("/doLogin")
+    @Operation(summary = "일반 로그인")
+    @UserErrorDocs({UserErrorCode.USER_NOT_FOUND, UserErrorCode.AUTHENTICATION_FAILED})
+    public ResponseEntity<AuthResponse> login(@Valid @RequestBody EmailLoginDto req) {
+        AuthResponse response = userService.login(req);
+        return ResponseEntity.ok(response);
+    }
 
     @Operation(summary = "구글 소셜 로그인", description = "앱에서 받은 인증 코드로 구글 로그인을 처리하고 JWT를 발급합니다.")
     @PostMapping("/google/app-login")
@@ -84,6 +88,7 @@ public class LoginRegisterController {
     }
 
     @PostMapping("/logout")
+    @AuthErrorDocs({AuthErrorCode.INVALID_REFRESH_TOKEN,AuthErrorCode.INVALID_TOKEN })
     @Operation(summary = "로그아웃 API", description = "현재 사용자의 액세스 토큰을 블랙리스트에 등록하고, 리프레시 토큰을 삭제합니다.")
     public ResponseEntity<Void> logout(HttpServletRequest request) {
         String authHeader = request.getHeader("Authorization");
@@ -93,14 +98,6 @@ public class LoginRegisterController {
         }
         return ResponseEntity.noContent().build();
     }
-
-    @PostMapping("/refresh")
-    @Operation(summary = "토큰 재발급 API", description = "리프레시 토큰으로 새로운 액세스 토큰과 리프레시 토큰을 발급합니다.")
-    public ResponseEntity<ApiResponse<TokenRefreshResponse>> refreshToken(@RequestBody TokenRefreshRequest request) {
-        TokenRefreshResponse responseDto = userService.refreshTokens(request.refreshToken());
-        return ResponseEntity.ok(ApiResponse.success(responseDto));
-    }
-
     @Operation(summary = "애플 소셜 로그인", description = "앱에서 받은 identityToken으로 애플 로그인을 처리하고 JWT를 발급합니다.")
     @PostMapping("/apple/app-login")
     @AuthErrorDocs({AuthErrorCode.INVALID_APPLE_REQUEST})
@@ -118,6 +115,14 @@ public class LoginRegisterController {
             ApiResponse<LoginResponseDto> errorResponse = ApiResponse.fail("로그인 실패: " + e.getMessage());
             return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
         }
+    }
+
+    @PostMapping("/refresh")
+    @AuthErrorDocs({AuthErrorCode.INVALID_REFRESH_TOKEN,AuthErrorCode.INVALID_TOKEN })
+    @Operation(summary = "토큰 재발급 API", description = "리프레시 토큰으로 새로운 액세스 토큰과 리프레시 토큰을 발급합니다.")
+    public ResponseEntity<ApiResponse<TokenRefreshResponse>> refreshToken(@RequestBody TokenRefreshRequest request) {
+        TokenRefreshResponse responseDto = userService.refreshTokens(request.refreshToken());
+        return ResponseEntity.ok(ApiResponse.success(responseDto));
     }
 
     @GetMapping("/{userId}/info")
@@ -164,13 +169,6 @@ public class LoginRegisterController {
         return ResponseEntity.ok(ApiResponse.success(result));
     }
 
-    @PostMapping("/doLogin")
-    @Operation(summary = "일반 로그인")
-    @UserErrorDocs({UserErrorCode.USER_NOT_FOUND, UserErrorCode.AUTHENTICATION_FAILED})
-    public ResponseEntity<AuthResponse> login(@Valid @RequestBody EmailLoginDto req) {
-        AuthResponse response = userService.login(req);
-        return ResponseEntity.ok(response);
-    }
 
     @Operation(summary = "관리자 웹페이지 전용 로그인",
             description = "관리자 계정(ADMIN)인지 확인하고, HttpOnly 쿠키에 accessToken을 발급합니다.")

--- a/src/main/java/core/domain/user/controller/LoginRegisterController.java
+++ b/src/main/java/core/domain/user/controller/LoginRegisterController.java
@@ -6,7 +6,7 @@ import core.domain.user.entity.User;
 import core.domain.user.repository.UserRepository;
 import core.domain.user.service.UserService;
 import core.global.apple.dto.AppleLoginByCodeRequest;
-import core.global.apple.dto.withdrawIsApple;
+import core.global.apple.dto.WithdrawIsApple;
 import core.global.apple.service.AppleAuthService;
 import core.global.config.CustomUserDetails;
 import core.global.docs.annotations.AuthErrorDocs;
@@ -66,6 +66,7 @@ public class LoginRegisterController {
     private final FeatureUsageMetrics featureUsageMetrics;
     private final CookieUtil cookieUtil;
     private final GeoService geoService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @GetMapping("/google/callback")
     public String handleGoogleLogin(@RequestParam(required = false) String code,
@@ -268,13 +269,10 @@ public class LoginRegisterController {
     @DeleteMapping("/withdraw")
     @Operation(summary = "회원 탈퇴 API", description = "현재 로그인한 사용자의 계정을 삭제합니다")
     @UserErrorDocs({UserErrorCode.USER_NOT_FOUND})
-    public ResponseEntity<withdrawIsApple> withdraw(HttpServletRequest request) {
-        CustomUserDetails principal = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        Long userId = principal.getUserId();
-        String authHeader = request.getHeader("Authorization");
-        String accessToken = authHeader.substring(7);
-        boolean isapple = userService.withdrawUser(userId, accessToken);
-        withdrawIsApple withdrawIsApple = new withdrawIsApple(isapple);
+    public ResponseEntity<WithdrawIsApple> withdraw(HttpServletRequest request , @AuthenticationPrincipal CustomUserDetails principal) {
+        String accessToken = jwtTokenProvider.resolveToken(request);
+        boolean isapple = userService.withdrawUser(principal.getUserId(), accessToken);
+        WithdrawIsApple withdrawIsApple = new WithdrawIsApple(isapple);
         return ResponseEntity.ok(withdrawIsApple);
     }
 

--- a/src/main/java/core/domain/user/service/UserService.java
+++ b/src/main/java/core/domain/user/service/UserService.java
@@ -108,6 +108,60 @@ public class UserService {
     private static String nullToEmpty(String s) {
         return s == null ? "" : s;
     }
+    public void logout(String accessToken) {
+        // 1. 남은 유효시간 계산
+        long expiration = jwtTokenProvider.getExpiration(accessToken).getTime() - System.currentTimeMillis();
+
+        // 2. Access Token 블랙리스트 등록
+        redisService.blacklistAccessToken(accessToken, expiration);
+
+        // 3. Redis에서 Refresh Token 삭제
+        Long userId = jwtTokenProvider.getUserIdFromAccessToken(accessToken);
+        redisService.deleteRefreshToken(userId);
+
+        log.info("사용자 {} 로그아웃 처리 완료 (Service).", userId);
+    }
+
+    // --- [추가된 로직] 토큰 재발급 ---
+    public TokenRefreshResponse refreshTokens(String refreshToken) {
+        log.info("--- [토큰 재발급 Service] 시작 ---");
+
+        // 1. Refresh Token 유효성 검사
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            log.warn("유효하지 않은 리프레시 토큰 요청");
+            throw new BusinessException(AuthErrorCode.INVALID_TOKEN); // 적절한 ErrorCode 사용
+        }
+
+        // 2. 사용자 조회
+        Long userId = jwtTokenProvider.getUserIdFromRefreshToken(refreshToken);
+        User user = userRepository.getUserById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        // 3. Redis에 저장된 Refresh Token과 비교 (탈취 감지)
+        String storedRefreshToken = redisService.getRefreshToken(userId);
+
+        if (storedRefreshToken == null || !storedRefreshToken.equals(refreshToken)) {
+            log.warn("Redis의 리프레시 토큰과 불일치. 탈취 가능성. 사용자 ID: {}", userId);
+            // 보안상 저장된 토큰도 삭제
+            redisService.deleteRefreshToken(userId);
+            throw new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN); // 혹은 재로그인 유도 에러
+        }
+
+        // 4. 기존 토큰 삭제 및 새 토큰 생성
+        redisService.deleteRefreshToken(userId);
+
+        String newAccessToken = jwtTokenProvider.createAccessToken(userId, user.getUserRole().toString(), user.getEmail());
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(userId);
+
+        // 5. 새 Refresh Token Redis 저장
+        Date expirationDate = jwtTokenProvider.getExpiration(newRefreshToken);
+        long expirationMillis = expirationDate.getTime() - System.currentTimeMillis();
+        redisService.saveRefreshToken(userId, newRefreshToken, expirationMillis);
+
+        log.info("--- [토큰 재발급 Service] 완료. 사용자 ID: {} ---", userId);
+
+        return new TokenRefreshResponse(newAccessToken, newRefreshToken, userId);
+    }
 
     public User create(UserCreateDto memberCreateDto) {
         User user = User.builder()

--- a/src/main/java/core/domain/user/service/UserService.java
+++ b/src/main/java/core/domain/user/service/UserService.java
@@ -39,6 +39,7 @@ import core.global.exception.BusinessException;
 import core.global.redis.service.RedisService;
 import core.global.security.JwtTokenProvider;
 import core.global.service.SmtpMailService;
+import core.global.userfeedback.UserFeedbackRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -73,6 +74,7 @@ public class UserService {
     private static final String EMAIL_VERIFY_ATTEMPT_KEY = "auth:verify-attempt:";
     private static final long CODE_TTL_MIN = 3L;
     private static final long VERIFIED_TTL_MIN = 10L;
+
     /**
      * 8~12자, 특수문자(@/!/~) 1+ 포함, 허용문자 제한
      */
@@ -103,6 +105,7 @@ public class UserService {
     private final UserDeviceTokenRepository userDeviceTokenRepository;
     private final NotificationRepository notificationRepository;
     private final UserNotificationSettingRepository userNotificationSettingRepository;
+    private final UserFeedbackRepository userFeedbackRepository;
     Pattern pattern = Pattern.compile("\\[(.*?)\\]");
 
     private static String nullToEmpty(String s) {
@@ -826,6 +829,7 @@ public class UserService {
         notificationRepository.deleteAllByUserId(userId);
         notificationRepository.deleteAllByActorId(userId);
         userRepository.delete(user);
+        userFeedbackRepository.deleteAllByUser(user);
     }
 
     /**

--- a/src/main/java/core/domain/user/service/UserService.java
+++ b/src/main/java/core/domain/user/service/UserService.java
@@ -109,51 +109,40 @@ public class UserService {
         return s == null ? "" : s;
     }
     public void logout(String accessToken) {
-        // 1. 남은 유효시간 계산
         long expiration = jwtTokenProvider.getExpiration(accessToken).getTime() - System.currentTimeMillis();
-
-        // 2. Access Token 블랙리스트 등록
         redisService.blacklistAccessToken(accessToken, expiration);
-
-        // 3. Redis에서 Refresh Token 삭제
         Long userId = jwtTokenProvider.getUserIdFromAccessToken(accessToken);
         redisService.deleteRefreshToken(userId);
 
         log.info("사용자 {} 로그아웃 처리 완료 (Service).", userId);
     }
 
-    // --- [추가된 로직] 토큰 재발급 ---
     public TokenRefreshResponse refreshTokens(String refreshToken) {
         log.info("--- [토큰 재발급 Service] 시작 ---");
 
-        // 1. Refresh Token 유효성 검사
         if (!jwtTokenProvider.validateToken(refreshToken)) {
             log.warn("유효하지 않은 리프레시 토큰 요청");
             throw new BusinessException(AuthErrorCode.INVALID_TOKEN); // 적절한 ErrorCode 사용
         }
 
-        // 2. 사용자 조회
         Long userId = jwtTokenProvider.getUserIdFromRefreshToken(refreshToken);
         User user = userRepository.getUserById(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
-        // 3. Redis에 저장된 Refresh Token과 비교 (탈취 감지)
         String storedRefreshToken = redisService.getRefreshToken(userId);
 
         if (storedRefreshToken == null || !storedRefreshToken.equals(refreshToken)) {
             log.warn("Redis의 리프레시 토큰과 불일치. 탈취 가능성. 사용자 ID: {}", userId);
-            // 보안상 저장된 토큰도 삭제
             redisService.deleteRefreshToken(userId);
-            throw new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN); // 혹은 재로그인 유도 에러
+            throw new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
         }
 
-        // 4. 기존 토큰 삭제 및 새 토큰 생성
+
         redisService.deleteRefreshToken(userId);
 
         String newAccessToken = jwtTokenProvider.createAccessToken(userId, user.getUserRole().toString(), user.getEmail());
         String newRefreshToken = jwtTokenProvider.createRefreshToken(userId);
 
-        // 5. 새 Refresh Token Redis 저장
         Date expirationDate = jwtTokenProvider.getExpiration(newRefreshToken);
         long expirationMillis = expirationDate.getTime() - System.currentTimeMillis();
         redisService.saveRefreshToken(userId, newRefreshToken, expirationMillis);

--- a/src/main/java/core/global/apple/dto/WithdrawIsApple.java
+++ b/src/main/java/core/global/apple/dto/WithdrawIsApple.java
@@ -1,0 +1,4 @@
+package core.global.apple.dto;
+
+public record WithdrawIsApple(boolean isApple) {
+}

--- a/src/main/java/core/global/apple/dto/withdrawIsApple.java
+++ b/src/main/java/core/global/apple/dto/withdrawIsApple.java
@@ -1,4 +1,0 @@
-package core.global.apple.dto;
-
-public record withdrawIsApple(boolean isApple) {
-}

--- a/src/main/java/core/global/apple/service/AppleAuthService.java
+++ b/src/main/java/core/global/apple/service/AppleAuthService.java
@@ -6,6 +6,7 @@ import core.global.apple.client.AppleClient;
 import core.global.apple.dto.AppleLoginByCodeRequest;
 import core.global.apple.dto.ApplePublicKeyResponse;
 import core.global.apple.dto.AppleRefreshTokenResponse;
+import core.global.enums.errorcode.UserErrorCode;
 import core.global.security.JwtTokenProvider;
 import core.global.dto.*;
 import core.global.enums.Ouathplatform;
@@ -17,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
@@ -91,44 +93,21 @@ public class AppleAuthService {
             throw new BusinessException(AuthErrorCode.INVALID_JWT_APPLE);
         }
     }
-
+    @Transactional
     public LoginResponseDto login(AppleLoginByCodeRequest req) {
+        // 1. Identity Token 검증 및 Claims 추출
         Claims claims = verifyAndGetClaims(req.identityToken(), req.nonce());
-        String appleSocialId = claims.getSubject();
+        String socialId = claims.getSubject();
+        String email = claims.get("email", String.class);
         String provider = Ouathplatform.APPLE.toString();
 
-        User user = userService.getUserBySocialIdAndProvider(appleSocialId, provider);
-        if (user == null) {
-            String appleRefreshToken = requestAppleToken(req.authorizationCode());
-            String emailFromToken = claims.get("email", String.class);
-            user = userService.createAppleOauth(
-                    appleSocialId,
-                    emailFromToken,
-                    provider,
-                    appleRefreshToken,
-                    req.fullName()
-            );
-        } else if (user.isNewUser() && user.getProvider().equals(Ouathplatform.APPLE.toString())) {
-            AppleLoginByCodeRequest.FullNameDto fullName = req.fullName();
-            if (fullName != null) {
-                boolean needsUpdate = false;
-                if (fullName.givenName() != null && !fullName.givenName().isBlank()) {
-                    user.updateFirstName(fullName.givenName());
-                    needsUpdate = true;
-                }
-                if (fullName.familyName() != null && !fullName.familyName().isBlank()) {
-                    user.updateLastName(fullName.familyName());
-                    needsUpdate = true;
-                }
+        // 2. 유저 조회 또는 생성 (여기서 이메일 중복 체크 수행)
+        User user = findOrCreateUser(socialId, email, provider, req);
 
+        // 3. 이름 정보 업데이트 (Apple은 최초 가입 시에만 이름을 줌, 혹은 이름 정보가 누락된 경우 보완)
+        updateUserNameIfNeeded(user, req.fullName());
 
-                if (needsUpdate) {
-                    userService.updateUser(user,fullName);
-                }
-            }
-        }
-
-        boolean isNewUserResponse = user.isNewUser();
+        // 4. JWT 토큰 발급 및 Redis 저장
         String accessToken = jwtTokenProvider.createAccessToken(user.getId(), user.getUserRole().toString(), user.getEmail());
         String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
 
@@ -136,7 +115,73 @@ public class AppleAuthService {
         long expirationMillis = expirationDate.getTime() - System.currentTimeMillis();
         redisService.saveRefreshToken(user.getId(), refreshToken, expirationMillis);
 
-        return new LoginResponseDto(user.getId(), accessToken, refreshToken, isNewUserResponse);
+        // 5. 로그인 이벤트 발행 (필요하다면 여기서, 혹은 컨트롤러에서)
+        // publisher.publishEvent(...)
+
+        return new LoginResponseDto(user.getId(), accessToken, refreshToken, user.isNewUser());
+    }
+
+    /**
+     * 유저를 찾거나, 없으면 새로 생성합니다.
+     * ★ 중요: 이메일 중복 검사를 수행하여 DB 에러를 방지합니다.
+     */
+    private User findOrCreateUser(String socialId, String email, String provider, AppleLoginByCodeRequest req) {
+        // A. 소셜 ID로 가입된 유저 찾기
+        User user = userService.getUserBySocialIdAndProvider(socialId, provider);
+        if (user != null) {
+            return user;
+        }
+
+        // B. 가입된 유저는 아닌데, 이메일이 이미 존재하는 경우 (다른 소셜/일반 가입) 체크
+        // Apple은 이메일을 비공개(null)로 줄 수도 있으므로 null 체크 필수
+        if (email != null && userService.existsByEmail(email)) {
+            throw new BusinessException(UserErrorCode.DUPLICATE_EMAIL_PROVIDER_MISMATCH);
+        }
+
+        // C. 신규 회원가입 진행
+        // Apple Refresh Token은 회원가입 시(최초)에만 발급받아 저장
+        String appleRefreshToken = requestAppleToken(req.authorizationCode());
+
+        return userService.createAppleOauth(
+                socialId,
+                email,
+                provider,
+                appleRefreshToken,
+                req.fullName()
+        );
+    }
+
+    /**
+     * Apple 로그인 요청에 이름 정보가 있고, 유저에게 업데이트가 필요한 경우 처리
+     */
+    private void updateUserNameIfNeeded(User user, AppleLoginByCodeRequest.FullNameDto fullName) {
+        // 유저가 새로 가입 상태이거나, 이름이 아직 설정되지 않은 경우 등 조건 확인
+        // (Apple은 최초 로그인 시에만 fullName을 보내주므로, 이때 놓치면 안 됨)
+        if (fullName == null) return;
+
+        boolean needsUpdate = false;
+
+        if (hasText(fullName.givenName()) && !fullName.givenName().equals(user.getFirstName())) {
+            user.updateFirstName(fullName.givenName());
+            needsUpdate = true;
+        }
+
+        if (hasText(fullName.familyName()) && !fullName.familyName().equals(user.getLastName())) {
+            user.updateLastName(fullName.familyName());
+            needsUpdate = true;
+        }
+
+        if (needsUpdate) {
+            // 이미 Transactional 안이므로 user.update...() 만으로 DB 반영됨.
+            // 별도로 userService.updateUser(user, fullName) 호출 안 해도 됨 (Dirty Checking)
+            // 하지만 명시적으로 호출해야 하는 구조라면 유지.
+            userService.updateUser(user, fullName);
+        }
+    }
+
+    // 문자열 유효성 검사 헬퍼 (StringUtils.hasText 대용)
+    private boolean hasText(String str) {
+        return str != null && !str.isBlank();
     }
     /**
      * authorizationCode를 사용해 Apple 서버에 토큰 발급을 요청하고, refresh_token을 반환하는 private 메소드

--- a/src/main/java/core/global/apple/service/AppleAuthService.java
+++ b/src/main/java/core/global/apple/service/AppleAuthService.java
@@ -95,28 +95,19 @@ public class AppleAuthService {
     }
     @Transactional
     public LoginResponseDto login(AppleLoginByCodeRequest req) {
-        // 1. Identity Token 검증 및 Claims 추출
         Claims claims = verifyAndGetClaims(req.identityToken(), req.nonce());
         String socialId = claims.getSubject();
         String email = claims.get("email", String.class);
         String provider = Ouathplatform.APPLE.toString();
-
-        // 2. 유저 조회 또는 생성 (여기서 이메일 중복 체크 수행)
         User user = findOrCreateUser(socialId, email, provider, req);
 
-        // 3. 이름 정보 업데이트 (Apple은 최초 가입 시에만 이름을 줌, 혹은 이름 정보가 누락된 경우 보완)
         updateUserNameIfNeeded(user, req.fullName());
-
-        // 4. JWT 토큰 발급 및 Redis 저장
         String accessToken = jwtTokenProvider.createAccessToken(user.getId(), user.getUserRole().toString(), user.getEmail());
         String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
 
         Date expirationDate = jwtTokenProvider.getExpiration(refreshToken);
         long expirationMillis = expirationDate.getTime() - System.currentTimeMillis();
         redisService.saveRefreshToken(user.getId(), refreshToken, expirationMillis);
-
-        // 5. 로그인 이벤트 발행 (필요하다면 여기서, 혹은 컨트롤러에서)
-        // publisher.publishEvent(...)
 
         return new LoginResponseDto(user.getId(), accessToken, refreshToken, user.isNewUser());
     }
@@ -126,20 +117,15 @@ public class AppleAuthService {
      * ★ 중요: 이메일 중복 검사를 수행하여 DB 에러를 방지합니다.
      */
     private User findOrCreateUser(String socialId, String email, String provider, AppleLoginByCodeRequest req) {
-        // A. 소셜 ID로 가입된 유저 찾기
         User user = userService.getUserBySocialIdAndProvider(socialId, provider);
         if (user != null) {
             return user;
         }
 
-        // B. 가입된 유저는 아닌데, 이메일이 이미 존재하는 경우 (다른 소셜/일반 가입) 체크
-        // Apple은 이메일을 비공개(null)로 줄 수도 있으므로 null 체크 필수
         if (email != null && userService.existsByEmail(email)) {
             throw new BusinessException(UserErrorCode.DUPLICATE_EMAIL_PROVIDER_MISMATCH);
         }
 
-        // C. 신규 회원가입 진행
-        // Apple Refresh Token은 회원가입 시(최초)에만 발급받아 저장
         String appleRefreshToken = requestAppleToken(req.authorizationCode());
 
         return userService.createAppleOauth(
@@ -155,8 +141,6 @@ public class AppleAuthService {
      * Apple 로그인 요청에 이름 정보가 있고, 유저에게 업데이트가 필요한 경우 처리
      */
     private void updateUserNameIfNeeded(User user, AppleLoginByCodeRequest.FullNameDto fullName) {
-        // 유저가 새로 가입 상태이거나, 이름이 아직 설정되지 않은 경우 등 조건 확인
-        // (Apple은 최초 로그인 시에만 fullName을 보내주므로, 이때 놓치면 안 됨)
         if (fullName == null) return;
 
         boolean needsUpdate = false;
@@ -172,14 +156,10 @@ public class AppleAuthService {
         }
 
         if (needsUpdate) {
-            // 이미 Transactional 안이므로 user.update...() 만으로 DB 반영됨.
-            // 별도로 userService.updateUser(user, fullName) 호출 안 해도 됨 (Dirty Checking)
-            // 하지만 명시적으로 호출해야 하는 구조라면 유지.
             userService.updateUser(user, fullName);
         }
     }
 
-    // 문자열 유효성 검사 헬퍼 (StringUtils.hasText 대용)
     private boolean hasText(String str) {
         return str != null && !str.isBlank();
     }

--- a/src/main/java/core/global/enums/errorcode/AuthErrorCode.java
+++ b/src/main/java/core/global/enums/errorcode/AuthErrorCode.java
@@ -37,8 +37,10 @@ public enum AuthErrorCode implements AppError {
     AUTHENTICATION_ADMIN_FAILED(HttpStatus.UNAUTHORIZED, "관리자 계정이 아닙니다. 접근 권한이 없습니다."),
     VERIFY_CODE_EXPIRES(HttpStatus.BAD_REQUEST, "인증 코드가 만료되었거나 존재하지 않습니다."),
     VERIFY_CODE_NOT_MATCH(HttpStatus.CONFLICT, "인증 코드가 일치하지 않습니다."),
-    VERIFY_CODE_NEED_RESEND(HttpStatus.BAD_REQUEST, "인증 코드를 다시 요청해야 합니다.");
-
+    VERIFY_CODE_NEED_RESEND(HttpStatus.BAD_REQUEST, "인증 코드를 다시 요청해야 합니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 유효하지 않거나 만료되었습니다."),
+    // [추가 권장] 토큰 자체가 형식이 잘못되었거나 만료된 경우
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/core/global/enums/errorcode/UserErrorCode.java
+++ b/src/main/java/core/global/enums/errorcode/UserErrorCode.java
@@ -18,6 +18,8 @@ public enum UserErrorCode implements AppError {
     PASSWORD_FORM_FAILED(HttpStatus.BAD_REQUEST, "비밀번호는 8~12자, 대/소문자 각 1자 이상 포함하고 특수문자(@/!/~)를 1개 이상 포함해야 합니다."),
     PASSWORD_NOT_CORRECTED(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     CANNOT_FOLLOW_YOURSELF(HttpStatus.BAD_REQUEST, "자기자신은  팔로우가 불가능합니다."),
+    DUPLICATE_EMAIL_PROVIDER_MISMATCH(HttpStatus.CONFLICT, "다른 방식으로 가입된 이메일입니다."),
+
 
     ALREADY_BLOCKED (HttpStatus.CONFLICT, "이미 차단한 유저입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),

--- a/src/main/java/core/global/security/JwtTokenProvider.java
+++ b/src/main/java/core/global/security/JwtTokenProvider.java
@@ -7,6 +7,7 @@ import core.global.exception.BusinessException;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.stereotype.Component;
@@ -188,7 +189,13 @@ public class JwtTokenProvider {
                         .getSubject()
         );
     }
-
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
 
 
 }

--- a/src/main/java/core/global/service/GoogleAuthService.java
+++ b/src/main/java/core/global/service/GoogleAuthService.java
@@ -3,6 +3,8 @@ package core.global.service;
 
 import core.domain.user.entity.User;
 import core.domain.user.service.UserService;
+import core.global.enums.errorcode.UserErrorCode;
+import core.global.exception.BusinessException;
 import core.global.security.JwtTokenProvider;
 import core.global.dto.AccessTokenDto;
 import core.global.dto.GoogleProfileDto;
@@ -51,9 +53,9 @@ public class GoogleAuthService {
 
     private User findOrCreateUser(GoogleProfileDto profile) {
         User user = userService.getUserBySocialIdAndProvider(profile.getSub(), String.valueOf(Ouathplatform.GOOGLE));
-        if (user == null) {
-            user = userService.createOauth(profile.getSub(), profile.getEmail(), String.valueOf(Ouathplatform.GOOGLE));
+        if (userService.existsByEmail(profile.getEmail())) {
+            throw new BusinessException(UserErrorCode.DUPLICATE_EMAIL_PROVIDER_MISMATCH);
         }
-        return user;
+        return userService.createOauth(profile.getSub(), profile.getEmail(), String.valueOf(Ouathplatform.GOOGLE));
     }
 }

--- a/src/main/java/core/global/service/GoogleAuthService.java
+++ b/src/main/java/core/global/service/GoogleAuthService.java
@@ -53,6 +53,9 @@ public class GoogleAuthService {
 
     private User findOrCreateUser(GoogleProfileDto profile) {
         User user = userService.getUserBySocialIdAndProvider(profile.getSub(), String.valueOf(Ouathplatform.GOOGLE));
+        if (user != null) {
+            return user;
+        }
         if (userService.existsByEmail(profile.getEmail())) {
             throw new BusinessException(UserErrorCode.DUPLICATE_EMAIL_PROVIDER_MISMATCH);
         }

--- a/src/main/java/core/global/userfeedback/UserFeedbackRepository.java
+++ b/src/main/java/core/global/userfeedback/UserFeedbackRepository.java
@@ -4,4 +4,5 @@ import core.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 public interface UserFeedbackRepository extends JpaRepository<UserFeedback, Long> {
     boolean existsByUser(User user);
+    void deleteAllByUser(User user);
 }


### PR DESCRIPTION
### 📄 PR 변경사항
OAuth 로그인 안정성 강화: 이메일 중복 시 500 에러 방지 로직 추가
Controller 리팩토링: 비즈니스 로직을 Service 계층으로 이관 (SRP 준수)
JWT 유틸리티 개선: 토큰 추출 로직 공통화 및 안전성 확보
FCM SENDER_ID_MISMATCH 에러 핸들링 및 무효 토큰 자동 삭제

- Firebase 프로젝트 변경으로 인한 SENDER_ID_MISMATCH 에러 발생 시, 에러 로그를 남기지 않도록 수정 (Log Spam 방지)
- 해당 에러 발생 시 유효하지 않은 토큰으로 간주하여 DB에서 즉시 삭제 처리
- 단건(sendPush), 배치(sendBatch), 그룹(sendGroup) 발송 로직 전체 적용

### 🖌️ 구체적인 구현 내용
DB 에러 방어 로직 추가 (AppleAuthService, GoogleAuthService)
소셜 로그인/회원가입 시 findOrCreateUser에서 save를 호출하기 전에 existsByEmail로 중복 여부를 먼저 검사합니다.
중복 시 DataIntegrityViolationException 대신 커스텀 예외(DUPLICATE_EMAIL_PROVIDER_MISMATCH)를 던지도록 수정했습니다.
Controller 다이어트 (LoginRegisterController)
logout, refreshToken 로직을 UserService로 이동시켰습니다.
불필요한 try-catch 블록을 제거하고 GlobalExceptionHandler가 예외를 처리하도록 위임했습니다.
안전한 토큰 파싱 (JwtTokenProvider)
resolveToken(HttpServletRequest) 메서드를 추가하여 Authorization 헤더 파싱 로직을 캡슐화했습니다.
Firebase 프로젝트 변경으로 인한 SENDER_ID_MISMATCH 에러 발생 시, 에러 로그를 남기지 않도록 수정 (Log Spam 방지)
해당 에러 발생 시 유효하지 않은 토큰으로 간주하여 DB에서 즉시 삭제 처리

substring(7) 하드코딩으로 인한 NPE 위험을 제거했습니다.
### ✨개선 사항 및 참고 사항
기존에는 다른 소셜로 가입된 이메일로 로그인 시도 시 500 Internal Server Error가 발생했으나, 이제는 명확한 에러 메시지와 상태 코드가 반환됩니다.
컨트롤러의 코드가 간결해져 가독성과 유지보수성이 향상되었습니다.

### # 💯 테스트
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 

# 확인
- [ ] 주석 및 print를 제거하셨나요?
- [ ] javaDoc을 작성하셨나요?
- [ ] merge할 브랜치와 로컬에서 merge 하셨나요?
- [ ] 더 수정할 작업은 없는지 확인하셨나요?
