### PR TITLE
Fix/transrator api

### DIFF
--- a/src/main/java/core/domain/user/service/UserService.java
+++ b/src/main/java/core/domain/user/service/UserService.java
@@ -259,47 +259,40 @@ public class UserService {
 // UserSetupRequest dto를 받는 메서드 내부
         if (dto.language() != null && !dto.language().isEmpty()) {
 
-            // 1. [정제 로직] updateLanguage와 updateTranslateLanguage에 사용할 리스트 생성
-            List<String> languages = dto.language().stream()
+            // 1. 초기 정제: null, 공백 제거 및 trim만 수행. (대소문자/포맷은 유지)
+            List<String> rawLanguages = dto.language().stream()
                     .filter(Objects::nonNull)
                     .map(String::trim)
-                    .map(String::toLowerCase)
                     .filter(s -> !s.isEmpty())
                     .distinct()
                     .toList();
 
-            if (!languages.isEmpty()) {
-                // languages 컬럼에는 정제된 소문자 전체 리스트를 CSV로 저장
-                String userLanguagesCsv = String.join(",", languages);
-                user.updateLanguage(userLanguagesCsv);
+            if (!rawLanguages.isEmpty()) {
 
-                // 2. [대표 번역 언어 추출] (pattern 정의 필요)
-                String firstTranslatedLanguage = languages.stream()
-                        .map(s -> {
-                            // **주의:** pattern 객체가 어디에 정의되어 있는지 확인하고 가져와야 합니다.
-                            // 만약 pattern 객체가 없다면, 간단히 첫 번째 항목의 ISO 코드만 사용하거나,
-                            // 정규식 대신 단순 문자열 처리(예: substring)를 적용해야 합니다.
-
-                            // 정규식 Matcher 사용 (updateUserLanguage 로직 그대로 적용)
-                            Matcher matcher = pattern.matcher(s);
-                            if (matcher.find()) {
-                                return matcher.group(1).trim();
-                            }
-                            // [대안] 만약 정규식이 없거나 코드가 'ko'와 같이 바로 들어오는 경우
-                            if (s.length() <= 5 && !s.contains("[")) {
-                                return s;
-                            }
-                            return "";
-                        })
-                        .filter(s -> !s.isEmpty())
-                        .findFirst()
+                // 2. 번역 언어 (translate_language) 추출 및 저장 (무조건 소문자)
+                String firstTranslatedLanguage = rawLanguages.stream()
+                        .findFirst() // 첫 번째 언어를 선택
+                        .map(s -> normalizeLanguageCode(s).toLowerCase()) // 코드를 추출하고 소문자화
                         .orElse("");
 
                 if (!firstTranslatedLanguage.isEmpty()) {
                     user.updateTranslateLanguage(firstTranslatedLanguage);
                 }
+
+                // 3. 언어 목록 (languages CSV) 추출 및 저장 (무조건 대문자)
+                List<String> normalizedLanguagesForCsv = rawLanguages.stream()
+                        .map(s -> normalizeLanguageCode(s).toUpperCase()) // 코드를 추출하고 대문자화
+                        .filter(s -> !s.isEmpty())
+                        .distinct()
+                        .toList();
+
+                if (!normalizedLanguagesForCsv.isEmpty()) {
+                    String userLanguagesCsv = String.join(",", normalizedLanguagesForCsv);
+                    user.updateLanguage(userLanguagesCsv);
+                }
             }
         }
+
         if (dto.hobby() != null && !dto.hobby().isEmpty()) {
             String csv = String.join(",", dto.hobby());
             user.updateHobby(csv);
@@ -344,7 +337,30 @@ public class UserService {
 
         return new UserProfileResponse(user, stringToList(user.getTranslateLanguage()), stringToList(user.getHobby()), profileKey);
     }
+    private String normalizeLanguageCode(String rawLang) {
+        if (rawLang == null) return "";
 
+        String normalized = rawLang.toLowerCase().trim();
+
+        // 1. 정규식 패턴 기반 추출 (예: 'abkhaz [ab]' -> 'ab')
+        Matcher matcher = pattern.matcher(normalized);
+        if (matcher.find()) {
+            return matcher.group(1).trim();
+        }
+
+        // 2. 대시(-) 처리 (예: 'fr-fr' -> 'fr')
+        if (normalized.contains("-")) {
+            return normalized.split("-")[0].trim();
+        }
+
+        // 3. 단순 코드인 경우 (예: 'ko', 'en')
+        // 코드 길이가 2~5자인 경우 (예: zh-CN)는 그대로 반환
+        if (normalized.length() >= 2 && normalized.length() <= 5) {
+            return normalized;
+        }
+
+        return ""; // 그 외 알 수 없는 포맷은 무시
+    }
     @Transactional
     public void deleteProfileImage() {
         var auth = SecurityContextHolder.getContext().getAuthentication();

--- a/src/main/java/core/domain/user/service/UserService.java
+++ b/src/main/java/core/domain/user/service/UserService.java
@@ -643,30 +643,40 @@ public class UserService {
             user.updatePurpose(dto.purpose());
         }
 
+// UserLanguageDTO dto를 받는 메서드 내부 (updateUserLanguage 로직)
+
         if (dto.language() != null && !dto.language().isEmpty()) {
-            List<String> languages = dto.language().stream()
+
+            // 1. 초기 정제: null, 공백 제거 및 trim만 수행. (대소문자/포맷은 유지)
+            List<String> rawLanguages = dto.language().stream()
                     .filter(Objects::nonNull)
                     .map(String::trim)
-                    .map(String::toLowerCase)
                     .filter(s -> !s.isEmpty())
                     .distinct()
                     .toList();
 
-            if (!languages.isEmpty()) {
-                String userLanguagesCsv = String.join(",", languages);
-                user.updateLanguage(userLanguagesCsv);
+            if (!rawLanguages.isEmpty()) {
 
-                String firstTranslatedLanguage = languages.stream()
-                        .map(s -> {
-                            Matcher matcher = pattern.matcher(s);
-                            return matcher.find() ? matcher.group(1).trim() : "";
-                        })
-                        .filter(s -> !s.isEmpty())
-                        .findFirst()
+                // 2. 번역 언어 (translate_language) 추출 및 저장 (무조건 소문자)
+                String firstTranslatedLanguage = rawLanguages.stream()
+                        .findFirst() // 첫 번째 언어를 선택
+                        .map(s -> normalizeLanguageCode(s).toLowerCase()) // 코드를 추출하고 소문자화
                         .orElse("");
 
                 if (!firstTranslatedLanguage.isEmpty()) {
                     user.updateTranslateLanguage(firstTranslatedLanguage);
+                }
+
+                // 3. 언어 목록 (languages CSV) 추출 및 저장 (무조건 대문자)
+                List<String> normalizedLanguagesForCsv = rawLanguages.stream()
+                        .map(s -> normalizeLanguageCode(s).toUpperCase()) // 코드를 추출하고 대문자화
+                        .filter(s -> !s.isEmpty())
+                        .distinct()
+                        .toList();
+
+                if (!normalizedLanguagesForCsv.isEmpty()) {
+                    String userLanguagesCsv = String.join(",", normalizedLanguagesForCsv);
+                    user.updateLanguage(userLanguagesCsv);
                 }
             }
         }
@@ -710,37 +720,6 @@ public class UserService {
             responseDto.setNewTokens(accessToken, refreshToken);
         }
         return responseDto;
-    }
-
-    @Transactional
-    public LoginResponseDto finalizeSkipSetupAndReissueToken(UserUpdateDto dto) {
-
-        updateSkipUserSetup(dto);
-
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        String email = auth.getName();
-        User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
-
-        String accessToken = jwtTokenProvider.createAccessToken(
-                user.getId(),
-                user.getUserRole().name(),
-                user.getEmail()
-        );
-        String refreshToken = redisService.getRefreshToken(user.getId());
-        if (refreshToken == null) {
-            refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
-            long ttlMs = jwtTokenProvider.getExpiration(refreshToken).getTime() - System.currentTimeMillis();
-            redisService.saveRefreshToken(user.getId(), refreshToken, ttlMs);
-        }
-
-        publisher.publishEvent(new NewUserJoinedEvent(user.getId()));
-        return new LoginResponseDto(
-                user.getId(),
-                accessToken,
-                refreshToken,
-                user.isNewUser()
-        );
     }
 
     @Transactional

--- a/src/main/java/core/domain/user/service/UserService.java
+++ b/src/main/java/core/domain/user/service/UserService.java
@@ -256,16 +256,50 @@ public class UserService {
         String v = dto.introduction();
         user.updateIntroduction(v.length() > 70 ? v.substring(0, 70) : v);
 
+// UserSetupRequest dto를 받는 메서드 내부
         if (dto.language() != null && !dto.language().isEmpty()) {
-            String userLanguagesCsv = String.join(",", dto.language());
-            user.updateLanguage(userLanguagesCsv);
 
-            String firstTranslatedLanguage = dto.language().get(0);
-            if (firstTranslatedLanguage != null && !firstTranslatedLanguage.isEmpty()) {
-                user.updateTranslateLanguage(firstTranslatedLanguage);
+            // 1. [정제 로직] updateLanguage와 updateTranslateLanguage에 사용할 리스트 생성
+            List<String> languages = dto.language().stream()
+                    .filter(Objects::nonNull)
+                    .map(String::trim)
+                    .map(String::toLowerCase)
+                    .filter(s -> !s.isEmpty())
+                    .distinct()
+                    .toList();
+
+            if (!languages.isEmpty()) {
+                // languages 컬럼에는 정제된 소문자 전체 리스트를 CSV로 저장
+                String userLanguagesCsv = String.join(",", languages);
+                user.updateLanguage(userLanguagesCsv);
+
+                // 2. [대표 번역 언어 추출] (pattern 정의 필요)
+                String firstTranslatedLanguage = languages.stream()
+                        .map(s -> {
+                            // **주의:** pattern 객체가 어디에 정의되어 있는지 확인하고 가져와야 합니다.
+                            // 만약 pattern 객체가 없다면, 간단히 첫 번째 항목의 ISO 코드만 사용하거나,
+                            // 정규식 대신 단순 문자열 처리(예: substring)를 적용해야 합니다.
+
+                            // 정규식 Matcher 사용 (updateUserLanguage 로직 그대로 적용)
+                            Matcher matcher = pattern.matcher(s);
+                            if (matcher.find()) {
+                                return matcher.group(1).trim();
+                            }
+                            // [대안] 만약 정규식이 없거나 코드가 'ko'와 같이 바로 들어오는 경우
+                            if (s.length() <= 5 && !s.contains("[")) {
+                                return s;
+                            }
+                            return "";
+                        })
+                        .filter(s -> !s.isEmpty())
+                        .findFirst()
+                        .orElse("");
+
+                if (!firstTranslatedLanguage.isEmpty()) {
+                    user.updateTranslateLanguage(firstTranslatedLanguage);
+                }
             }
         }
-
         if (dto.hobby() != null && !dto.hobby().isEmpty()) {
             String csv = String.join(",", dto.hobby());
             user.updateHobby(csv);


### PR DESCRIPTION
# 📄 PR 변경사항
사용자 프로필 설정/수정/언어 업데이트 API에서 전송된 언어 코드를 정규화하고, 두 가지 DB 필드(translate_language, languages)의 요구사항에 맞춰 대소문자를 분리하여 저장하는 로직을 적용했습니다.
translate_language 필드가 항상 소문자 표준 ISO 코드를 갖도록 보장하여,
oogle Cloud Translation API 호출 시 InvalidArgumentException 발생 가능성을 원천적으로 제거했습니다.

# 🖌️ 구체적인 구현 내용
1. 일관된 언어 정규화 로직 통합
영향을 받는 메서드: setupUserProfile, updateUserLanguage, updateUserProfile
구현 고려 사항: 기존에는 각 API에서 언어 코드를 처리하는 방식이 일관되지 않거나, 대소문자 변환이 부족했습니다.
새로 추가된 normalizeLanguageCode 헬퍼 메서드를 통해 Abkhaz [AB], en-us, KO 등 비표준 또는 혼합된 입력 포맷을 처리하고 순수 ISO 코드를 추출하도록 로직을 통일했습니다.

2. 두 가지 필드에 대한 대소문자 분리 규칙 적용
translate_language (번역 대상 언어):
API의 요구사항에 따라 항상 소문자 표준 코드로 저장됩니다. (예: ko, fr)
예외 처리: 만약 정규화된 코드가 비어있다면(""), 해당 필드 업데이트를 건너뛰어 잘못된 값이 저장되는 것을 방지합니다.
languages (사용 가능 언어 목록 - CSV):
표시 목적으로 항상 대문자 표준 코드로 변환하여 쉼표로 구분된 문자열(CSV)로 저장됩니다. (예: KO,FR)

- 

# ✨개선 사항 및 참고 사항
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 


# 💯 테스트
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 

# 확인
- [ ] 주석 및 print를 제거하셨나요?
- [ ] javaDoc을 작성하셨나요?
- [ ] merge할 브랜치와 로컬에서 merge 하셨나요?
- [ ] 더 수정할 작업은 없는지 확인하셨나요?
