### PR TITLE
Fix/trainst chaing

### DIFF
--- a/src/main/java/core/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/core/domain/chat/controller/ChatMessageController.java
@@ -58,7 +58,7 @@ public class ChatMessageController {
         return ResponseEntity.ok(ApiResponse.success(responses));
     }
 
-    // [수정 2] List 반환 명시 (@ArraySchema)
+
     @Operation(summary = "첫 채팅방 메시지 조회", description = "채팅방에 처음 입장 시 가장 최근 메시지 50개를 조회합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공",

--- a/src/main/java/core/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/core/domain/chat/service/ChatMessageService.java
@@ -66,7 +66,6 @@ public class ChatMessageService {
 
     // Service
     private final UserRoleDetectService userRoleDetectService;
-    private final TranslationService translationService;
     private final PerspectiveService perspectiveService;
     private final ChatMemberService chatMemberService;
     private final ChatSummaryService chatSummaryService;
@@ -275,24 +274,19 @@ public class ChatMessageService {
                             (existing, replacement) -> existing
                     ));
         }
-
+        final Map<Long, String> finalProfileMap = profileMap;
         if (needsTranslation && targetLanguage != null && !targetLanguage.isEmpty()) {
-            List<String> originalContents = messages.stream()
-                    .map(ChatMessage::getContent)
-                    .collect(Collectors.toList());
-            List<String> translatedContents = translationService.translateMessages(originalContents, targetLanguage);
 
-            List<ChatMessage> finalMessages = messages;
-            Map<Long, String> finalProfileMap = profileMap;
+            Map<Long, String> translatedMap = chatTranslationService.getTranslatedMessages(messages, targetLanguage);
 
-            return IntStream.range(0, messages.size())
-                    .mapToObj(i -> {
-                        ChatMessage message = finalMessages.get(i);
-                        String translatedContent = translatedContents.get(i);
+            return messages.stream()
+                    .map(message -> {
+                        String translatedContent = translatedMap.get(message.getId());
                         return mapToResponse(message, translatedContent, finalProfileMap);
-                    }).collect(Collectors.toList());
+                    })
+                    .collect(Collectors.toList());
+
         } else {
-            Map<Long, String> finalProfileMap = profileMap;
             return messages.stream()
                     .map(message -> mapToResponse(message, null, finalProfileMap))
                     .collect(Collectors.toList());
@@ -570,42 +564,36 @@ public class ChatMessageService {
 
         // 4. 번역 및 응답 변환 (검색된 소수의 메시지만 번역)
         if (needsTranslation && targetLanguage != null && !targetLanguage.isEmpty()) {
-            List<String> originalContents = messages.stream()
-                    .map(ChatMessage::getContent)
-                    .collect(Collectors.toList());
 
-            // 검색된 결과(예: 5개)만 번역하므로 매우 빠르고 비용이 적음
-            List<String> translatedContents = translationService.translateMessages(originalContents, targetLanguage);
+            // [변경] 외부 API 직접 호출(translationService) -> 캐싱 서비스(chatTranslationService) 사용
+            // 검색 결과가 5개라면, 5개 중 캐시 없는 것만 골라서 API 호출 후 저장까지 수행함
+            Map<Long, String> translatedMap = chatTranslationService.getTranslatedMessages(messages, targetLanguage);
 
-            List<ChatMessage> finalMessages = messages;
-            return IntStream.range(0, messages.size())
-                    .mapToObj(i -> {
-                        ChatMessage message = finalMessages.get(i);
-                        String translatedContent = translatedContents.get(i);
-                        return mapToResponse(message, translatedContent, profileMap); // 1단계의 mapToResponse 재사용
+            return messages.stream()
+                    .map(message -> {
+                        // ID로 번역된 내용 찾기 (Map 조회)
+                        String translatedContent = translatedMap.get(message.getId());
+                        return mapToResponse(message, translatedContent, profileMap);
                     })
                     .sorted(Comparator.comparing(ChatMessageResponse::sentAt, Comparator.reverseOrder()))
                     .collect(Collectors.toList());
+
         } else {
+            // 번역 미사용 시
             return messages.stream()
-                    .map(m -> mapToResponse(m, null, profileMap)) // 1단계의 mapToResponse 재사용
+                    .map(m -> mapToResponse(m, null, profileMap))
                     .sorted(Comparator.comparing(ChatMessageResponse::sentAt, Comparator.reverseOrder()))
                     .collect(Collectors.toList());
         }
     }
-    private List<String> getTranslatedMessages(List<ChatMessage> messages, ChatParticipant participant) {
-        if (participant.isTranslateEnabled() && participant.getUser().getTranslateLanguage() != null && !messages.isEmpty()) {
-            List<String> contents = messages.stream().map(ChatMessage::getContent).toList();
-            return translationService.translateMessages(contents, participant.getUser().getTranslateLanguage());
-        }
-        return Collections.emptyList();
-    }
+
     @Transactional(readOnly = true)
     public List<ChatMessageResponse> getMessagesAround(Long roomId, Long userId, Long targetMessageId) {
         // 1. 참여자 조회
         ChatParticipant participant = chatParticipantRepository.findByChatRoomIdAndUserId(roomId, userId)
                 .orElseThrow(() -> new BusinessException(ChatErrorCode.NOT_CHAT_PARTICIPANT));
 
+        // 2. 메시지 조회 (이전 20개, 타겟, 이후 20개)
         List<ChatMessage> older = chatMessageRepository.findTop20ByChatRoomIdAndIdLessThanOrderByIdDesc(roomId, targetMessageId);
         Collections.reverse(older);
 
@@ -618,12 +606,23 @@ public class ChatMessageService {
         combined.add(target);
         combined.addAll(newer);
 
-        List<String> translatedTexts = getTranslatedMessages(combined, participant);
 
-        return IntStream.range(0, combined.size())
-                .mapToObj(i -> {
-                    String translated = translatedTexts.isEmpty() ? null : translatedTexts.get(i);
-                    return mapToResponse(combined.get(i), translated);
+        // 3. [수정됨] 번역 처리 (캐싱 서비스 적용)
+        // 구형 로직(getTranslatedMessages 호출) 삭제됨
+        Map<Long, String> translatedMap = Collections.emptyMap(); // 기본값 빈 맵
+
+        if (participant.isTranslateEnabled() && participant.getUser().getTranslateLanguage() != null) {
+            // chatTranslationService가 Redis -> DB -> API 순서로 체크하고 저장까지 수행
+            translatedMap = chatTranslationService.getTranslatedMessages(combined, participant.getUser().getTranslateLanguage());
+        }
+
+        // 4. 응답 변환
+        Map<Long, String> finalTranslatedMap = translatedMap;
+        return combined.stream()
+                .map(msg -> {
+                    String translated = finalTranslatedMap.get(msg.getId());
+                    // mapToResponse 메서드 시그니처에 맞춰 호출 (프로필 맵이 필요하다면 여기서 추가 로직 필요)
+                    return mapToResponse(msg, translated);
                 })
                 .collect(Collectors.toList());
     }

--- a/src/main/java/core/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/core/domain/chat/service/ChatMessageService.java
@@ -74,7 +74,7 @@ public class ChatMessageService {
     private final S3Presigner s3Presigner;
     private final ApplicationEventPublisher eventPublisher;
     private final ChatMetrics chatMetrics;
-
+    private final ChatTranslationService chatTranslationService;
     @Value("${cdn.base-url}")
     private String cdnBaseUrl;
 
@@ -114,7 +114,7 @@ public class ChatMessageService {
 
             // 5. [핵심] 병렬 번역 실행 (Parallel Translation)
             Map<String, String> translatedContentsMap = executeParallelTranslations(
-                    savedMessage.getContent(), recipientsByLang.keySet()
+                    savedMessage.getId(), savedMessage.getContent(), recipientsByLang.keySet()
             );
 
             // 6. [핵심] 그룹별 비동기 발송 (Async Dispatch)
@@ -173,7 +173,7 @@ public class ChatMessageService {
     /**
      * 필요한 언어들에 대해 병렬로 번역을 수행합니다.
      */
-    private Map<String, String> executeParallelTranslations(String originalContent, Set<String> targetLanguages) {
+    private Map<String, String> executeParallelTranslations(Long messageId, String originalContent, Set<String> targetLanguages) {
         Map<String, String> resultMap = new ConcurrentHashMap<>();
 
         List<String> languagesToTranslate = targetLanguages.stream()
@@ -183,9 +183,10 @@ public class ChatMessageService {
         List<CompletableFuture<Void>> futures = languagesToTranslate.stream()
                 .map(lang -> CompletableFuture.runAsync(() -> {
                     try {
-                        List<String> results = translationService.translateMessages(List.of(originalContent), lang);
-                        if (!results.isEmpty()) {
-                            resultMap.put(lang, results.get(0));
+                        String translatedText = chatTranslationService.translateAndCache(messageId, originalContent, lang).join();
+
+                        if (translatedText != null) {
+                            resultMap.put(lang, translatedText);
                         }
                     } catch (Exception e) {
                         log.error("Translation failed for lang: {}", lang, e);

--- a/src/main/java/core/domain/user/controller/LoginRegisterController.java
+++ b/src/main/java/core/domain/user/controller/LoginRegisterController.java
@@ -284,15 +284,6 @@ public class LoginRegisterController {
         return ResponseEntity.ok(userProfiles);
     }
 
-    @Operation(summary = "유저 프로필 조회", description = "userId를 통해 유저의 상세 프로필 정보를 조회합니다.")
-    @GetMapping("/{userId}/chat_profile")
-    @UserErrorDocs({UserErrorCode.USER_NOT_FOUND})
-    @ImageErrorCodeDocs({ImageErrorCode.IMAGE_NOT_FOUND})
-    public ResponseEntity<ApiResponse<ChatUserProfileResponse>> getUserChatProfile(@PathVariable Long userId) {
-        ChatUserProfileResponse response = userService.getUserChatProfile(userId);
-        featureUsageMetrics.recordFollowUsage();
-        return ResponseEntity.ok(ApiResponse.success(response));
-    }
 
     @Operation(summary = "애플 유저인지 판별", description = "사용자가 애플 유저인지, 그리고 이름 정보가 없는 재가입 유저인지 판별합니다.")
     @GetMapping("/{userId}/is-apple")

--- a/src/main/java/core/domain/user/service/UserService.java
+++ b/src/main/java/core/domain/user/service/UserService.java
@@ -921,16 +921,6 @@ public class UserService {
                 .collect(Collectors.toList());
     }
 
-    @Transactional(readOnly = true)
-    public ChatUserProfileResponse getUserChatProfile(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
-
-        Image image = imageRepository.findFirstByImageTypeAndRelatedIdOrderByOrderIndexAsc(ImageType.USER, userId)
-                .orElseThrow(() -> new BusinessException(ImageErrorCode.IMAGE_NOT_FOUND));
-
-        return ChatUserProfileResponse.from(user, image.getUrl());
-    }
 
     /**
      * 사용자의 애플 계정 상태를 확인하는 메서드


### PR DESCRIPTION


# 📄 PR 변경사항
- **채팅 번역 시스템 최적화:** Redis/DB 캐싱 레이어 도입 및 전송/조회 로직 전반 리팩토링
- **비용 절감 및 성능 개선:** 중복된 외부 번역 API 호출 제거

# 🖌️ 구체적인 구현 내용
**1. `ChatTranslationService` (캐싱 계층) 구현**
- **Read Logic:** `Redis(Cache) -> DB(Persistence) -> External API` 순서로 데이터를 조회하여 API 호출을 최소화했습니다.
- **Write Logic:** 번역 발생 시 Redis와 DB에 비동기(`@Async`)로 데이터를 적재하여 이후 조회 시 캐시를 타도록 설계했습니다.

**2. 메시지 전송 로직 (`processAndSendChatMessage`) 개선**
- 기존에는 전송 시 번역만 하고 결과를 저장하지 않아 재조회 시 API 비용이 다시 발생하는 문제가 있었습니다.
- 전송 시점에 `translateAndCache()`를 호출하여, 번역 결과를 **비동기로 즉시 저장(Write-Through)** 하도록 수정했습니다.

**3. 조회 로직 (`getMessages`, `searchMessages`, `getMessagesAround`) 리팩토링**
- `translationService`를 직접 호출하던 레거시 코드를 제거하고, 캐싱 서비스(`ChatTranslationService`)를 경유하도록 변경했습니다.
- **안전한 매핑:** 기존의 `IntStream` 인덱스 의존 방식(순서 꼬임 위험)을 제거하고, `Map<Long, String>`을 사용하여 **Message ID 기반으로 매핑**하도록 수정하여 데이터 정합성을 확보했습니다.

# ✨개선 사항 및 참고 사항
- **비용 절감:** 이미 번역된 메시지나 검색 결과에 대해 불필요한 DeepL/Google API 호출이 발생하지 않습니다.
- **응답 속도:** Redis 캐시 Hit 시 API 네트워크 Latency 없이 즉각적인 응답이 가능합니다.
- **N+1 방지:** 프로필 이미지 조회 등 부가 정보 조회 시 Bulk Select를 유지/적용했습니다.

# 💯 테스트


# 확인
- [ ] 주석 및 print를 제거하셨나요?
- [ ] javaDoc을 작성하셨나요?
- [ ] merge할 브랜치와 로컬에서 merge 하셨나요?
- [ ] 더 수정할 작업은 없는지 확인하셨나요?