### PR TITLE
채팅방 버그 수정

### DIFF
--- a/src/main/java/core/domain/chat/controller/ChatMemberController.java
+++ b/src/main/java/core/domain/chat/controller/ChatMemberController.java
@@ -55,22 +55,7 @@ public class ChatMemberController {
         return ResponseEntity.ok(ApiResponse.success(responses));
     }
 
-    @Operation(summary = "유저 프로필 조회", description = "userId를 통해 유저의 상세 프로필 정보와 이미지 URL을 조회합니다.")
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공",
-                    content = @Content(schema = @Schema(implementation = ChatUserProfileResponse.class))
-            ),
-    })
-    @GetMapping("/users/{userId}/profile")
-    @ChatErrorDocs({ChatErrorCode.CHAT_ROOM_NOT_FOUND})
-    @UserErrorDocs({UserErrorCode.USER_NOT_FOUND, UserErrorCode.PROFILE_SET_NOT_COMPLETED})
-    public ResponseEntity<ApiResponse<ChatUserProfileResponse>> getUserProfile(@PathVariable Long userId) {
-        ChatUserProfileResponse response = chatService.getUserProfile(userId);
-        featureUsageMetrics.recordChatUsage();
-        return ResponseEntity.ok(ApiResponse.success(response));
-    }
 
-    // [수정 2] 리턴 타입 명확화 (<?> -> <String>)
     @Operation(summary = "특정 사용자 차단", description = "대화 상대를 차단합니다. 이미 차단되어 있거나 자기 자신은 차단할 수 없습니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "차단 성공"),

--- a/src/main/java/core/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/core/domain/chat/controller/ChatMessageController.java
@@ -59,26 +59,6 @@ public class ChatMessageController {
     }
 
 
-    @Operation(summary = "첫 채팅방 메시지 조회", description = "채팅방에 처음 입장 시 가장 최근 메시지 50개를 조회합니다.")
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공",
-                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = ChatMessageFirstResponse.class)))
-            ),
-    })
-    @GetMapping("/rooms/{roomId}/first_messages")
-    @ChatErrorDocs({ChatErrorCode.NOT_CHAT_PARTICIPANT, ChatErrorCode.CHAT_ROOM_NOT_FOUND})
-    @CommonErrorCodeDocs({CommonErrorCode.TRANSLATE_FAIL})
-    public ResponseEntity<ApiResponse<List<ChatMessageFirstResponse>>> getFirstMessages(
-            @PathVariable Long roomId,
-            @AuthenticationPrincipal CustomUserDetails principal
-    ) {
-        Long userId = principal.getUserId();
-        List<ChatMessageFirstResponse> responses = chatService.getFirstMessages(roomId, userId);
-        featureUsageMetrics.recordChatUsage();
-        return ResponseEntity.ok(ApiResponse.success(responses));
-    }
-
-    // [수정 3] List 반환 명시 (@ArraySchema)
     @Operation(summary = "메시지 키워드 검색", description = "메시지 내용을 키워드로 검색합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공",

--- a/src/main/java/core/domain/chat/dto/SendMessageRequest.java
+++ b/src/main/java/core/domain/chat/dto/SendMessageRequest.java
@@ -1,8 +1,16 @@
 package core.domain.chat.dto;
 
+import core.global.enums.MessageType;
+
 public record SendMessageRequest(
         Long roomId,
         Long senderId,
-        String content
+        String content,
+        MessageType type
 ) {
+    public SendMessageRequest {
+        if (type == null) {
+            type = MessageType.TEXT;
+        }
+    }
 }

--- a/src/main/java/core/domain/chat/service/ChatMemberService.java
+++ b/src/main/java/core/domain/chat/service/ChatMemberService.java
@@ -51,7 +51,6 @@ public class ChatMemberService {
                 .orElseThrow(() -> new BusinessException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
 
         List<ChatParticipant> participants = chatParticipantRepository.findByChatRoom(chatRoom);
-
         // TODO: 성능 최적화를 위해 이미지 조회를 In-Query로 변경하거나 배치 조회 권장 (현재는 N+1 발생 가능)
         return participants.stream()
                 .map(p -> {
@@ -97,19 +96,14 @@ public class ChatMemberService {
         if (targetUserId.equals(blockerId)) {
             throw new BusinessException(UserErrorCode.CANNOT_BLOCK);
         }
-
         User blocker = userRepository.findById(blockerId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
-
         User blockedUser = userRepository.findById(targetUserId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
-
         userRoleDetectService.isProfileSetUpUser(blocker);
-
         if (blockRepository.existsBlock(blocker.getId(), blockedUser.getId())) {
             throw new BusinessException(UserErrorCode.ALREADY_BLOCKED);
         }
-
         blockRepository.save(new BlockUser(blocker, blockedUser));
     }
 
@@ -118,20 +112,15 @@ public class ChatMemberService {
         if (chatReportRepository.existsByReporterUserIdAndMessageId(reporterUserId, request.messageId())) {
             throw new BusinessException(ChatErrorCode.DUPLICATE_REPORT);
         }
-
         User reporterUser = userRepository.findById(reporterUserId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
-
         ChatMessage reportedMessage = chatMessageRepository.findById(request.messageId())
                 .orElseThrow(() -> new BusinessException(ChatErrorCode.MESSAGE_NOT_FOUND));
-
         User reportedUser = reportedMessage.getSender();
         ChatRoom chatRoom = reportedMessage.getChatRoom();
-
         if (reportedUser.getId().equals(reporterUserId)) {
             throw new BusinessException(ChatErrorCode.CANNOT_REPORT_SELF);
         }
-
         ChatReport chatReport = new ChatReport(
                 reporterUser,
                 reportedUser,
@@ -150,7 +139,6 @@ public class ChatMemberService {
     public void toggleTranslation(Long roomId, Long userId, boolean enable) {
         ChatParticipant participant = chatParticipantRepository.findByChatRoomIdAndUserId(roomId, userId)
                 .orElseThrow(() -> new BusinessException(ChatErrorCode.NOT_CHAT_PARTICIPANT));
-
         participant.toggleTranslation(enable);
     }
 
@@ -158,7 +146,6 @@ public class ChatMemberService {
     public void toggleChatRoomNotifications(Long roomId, Long userId, boolean enabled) {
         ChatParticipant participant = chatParticipantRepository.findByChatRoomIdAndUserId(roomId, userId)
                 .orElseThrow(() -> new BusinessException(ChatErrorCode.CHAT_PARTICIPANT_NOT_FOUND));
-
         participant.setNotificationsEnabled(enabled);
     }
 
@@ -166,7 +153,6 @@ public class ChatMemberService {
     public ChatNotificationStatusResponse isNotificationsEnabled(Long roomId, Long userId) {
         ChatParticipant participant = chatParticipantRepository.findByChatRoomIdAndUserId(roomId, userId)
                 .orElseThrow(() -> new BusinessException(ChatErrorCode.CHAT_PARTICIPANT_NOT_FOUND));
-
         return new ChatNotificationStatusResponse(participant.isNotificationsEnabled());
     }
 }

--- a/src/main/java/core/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/core/domain/chat/service/ChatMessageService.java
@@ -504,54 +504,6 @@ public class ChatMessageService {
     }
 
     @Transactional(readOnly = true)
-    public List<ChatMessageFirstResponse> getFirstMessages(Long roomId, Long userId) {
-        // 채팅방 존재 확인
-        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
-                .orElseThrow(() -> new BusinessException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
-
-        // 참여 여부 확인
-        chatParticipantRepository.findByChatRoomIdAndUserId(roomId, userId)
-                .filter(participant -> participant.getStatus() != ChatParticipantStatus.LEFT)
-                .orElseThrow(() -> new BusinessException(ChatErrorCode.NOT_CHAT_PARTICIPANT));
-
-        // 최근 50개 조회
-        List<ChatMessage> messages = chatMessageRepository.findTop50ByChatRoomIdOrderBySentAtDesc(roomId);
-
-        // 차단 유저 제외
-        List<Long> blockedIds = getBlockedUserIds(userId);
-        if (!blockedIds.isEmpty()) {
-            messages = messages.stream()
-                    .filter(msg -> !blockedIds.contains(msg.getSender().getId()))
-                    .toList();
-        }
-
-        // 이미지 Bulk 조회
-        List<Long> senderIds = messages.stream().map(msg -> msg.getSender().getId()).distinct().toList();
-        Map<Long, String> senderImageUrlMap = new HashMap<>();
-
-        if (!senderIds.isEmpty()) {
-            List<Image> images = imageRepository.findAllByImageTypeAndRelatedIdInOrderByOrderIndexAsc(ImageType.USER, senderIds);
-            senderImageUrlMap = images.stream().collect(Collectors.toMap(
-                    Image::getRelatedId, Image::getUrl, (url1, url2) -> url1
-            ));
-        }
-
-        Map<Long, String> finalMap = senderImageUrlMap;
-        return messages.stream().map(message -> {
-            String finalContent = message.getContent();
-            MessageType finalType = message.getMessageType();
-
-            if ("BLOCKED_MEDIA".equals(finalContent)) {
-                finalContent = "관리자에 의해 삭제된 이미지입니다.";
-                finalType = MessageType.TEXT;
-            } else if (finalType == MessageType.IMAGE && !finalContent.startsWith("http")) {
-                finalContent = cdnBaseUrl + "/" + finalContent;
-            }
-            return ChatMessageFirstResponse.fromEntityWithContent(message, chatRoom, finalMap.get(message.getSender().getId()), finalContent, finalType);
-        }).collect(Collectors.toList());
-    }
-
-    @Transactional(readOnly = true)
     public List<ChatMessageResponse> searchMessages(Long roomId, Long userId, String keyword) {
         // 1. 참여자 검증
         ChatParticipant participant = chatParticipantRepository.findByChatRoomIdAndUserId(roomId, userId)

--- a/src/main/java/core/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/core/domain/chat/service/ChatMessageService.java
@@ -489,7 +489,7 @@ public class ChatMessageService {
         Optional<ChatMessage> lastMessageOpt = chatMessageRepository.findTopByChatRoomIdOrderByIdDesc(roomId);
         if (lastMessageOpt.isPresent()) {
             MarkAsReadRequest req = new MarkAsReadRequest(roomId, readerId, lastMessageOpt.get().getId());
-            processMarkAsRead(req, readerId);
+           // processMarkAsRead(req, readerId);
         }
     }
 

--- a/src/main/java/core/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/core/domain/chat/service/ChatMessageService.java
@@ -34,6 +34,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.util.StopWatch;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
@@ -43,6 +44,7 @@ import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignReques
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -210,36 +212,47 @@ public class ChatMessageService {
             ChatMessage savedMessage,
             String userImageUrl
     ) {
-        User sender = savedMessage.getSender();
-        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        // 1. 트랜잭션 안에서 데이터 미리 확보 (Lazy Loading 방지)
+        final Long messageId = savedMessage.getId();
+        final Long roomId = savedMessage.getChatRoom().getId();
+        final Long senderId = savedMessage.getSender().getId();
+        final String content = savedMessage.getContent();
+        final Instant sentAt = savedMessage.getSentAt();
+        final String senderFirstName = savedMessage.getSender().getFirstName();
+        final String senderLastName = savedMessage.getSender().getLastName();
+        final MessageType msgType = savedMessage.getMessageType();
 
-        for (Map.Entry<String, List<Long>> entry : recipientsByLang.entrySet()) {
-            String targetLang = entry.getKey();
-            List<Long> recipientIds = entry.getValue();
-            if (recipientIds.isEmpty()) continue;
+        // 2. ★ 핵심 수정: 트랜잭션 커밋 후(After Commit)에 실행되도록 예약
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                // 이 블록은 DB 커밋이 끝난 뒤에 실행됩니다.
+                // 따라서 비동기 스레드가 DB를 조회할 때 "방금 저장한 메시지"가 무조건 보입니다.
 
-            String translatedText = translatedContentsMap.get(targetLang);
-            ChatMessageResponse messageResponse = new ChatMessageResponse(
-                    savedMessage.getId(),
-                    savedMessage.getChatRoom().getId(),
-                    sender.getId(),
-                    savedMessage.getContent(),
-                    translatedText,
-                    savedMessage.getSentAt(),
-                    sender.getFirstName(),
-                    sender.getLastName(),
-                    userImageUrl,
-                    savedMessage.getMessageType()
+                List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+                for (Map.Entry<String, List<Long>> entry : recipientsByLang.entrySet()) {
+                    String targetLang = entry.getKey();
+                    List<Long> recipientIds = entry.getValue();
+                    if (recipientIds.isEmpty()) continue;
+
+                    String translatedText = translatedContentsMap.get(targetLang);
+
+                    // DTO 생성
+                    ChatMessageResponse messageResponse = new ChatMessageResponse(
+                            messageId, roomId, senderId, content, translatedText,
+                            sentAt, senderFirstName, senderLastName, userImageUrl, msgType
                     );
 
-            CompletableFuture<Void> future = CompletableFuture.runAsync(() ->
-                    chatSummaryService.sendSummaryToRecipientsInNewTx(messageResponse, recipientIds)
-            );
-            futures.add(future);
-        }
-        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+                    // 전송 로직 (기존과 동일)
+                    futures.add(CompletableFuture.runAsync(() ->
+                            chatSummaryService.sendSummaryToRecipientsInNewTx(messageResponse, recipientIds)
+                    ));
+                }
+                // Fire-and-Forget
+            }
+        });
     }
-
 
     @Transactional(readOnly = true)
     public List<ChatMessageResponse> getMessages(Long roomId, Long userId, Long lastMessageId) {

--- a/src/main/java/core/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/core/domain/chat/service/ChatMessageService.java
@@ -110,12 +110,14 @@ public class ChatMessageService {
             Map<String, List<Long>> recipientsByLang = groupRecipientsByLanguage(
                     chatRoom, sender, blockedUserIds, savedMessage.getId()
             );
-
             // 5. [핵심] 병렬 번역 실행 (Parallel Translation)
-            Map<String, String> translatedContentsMap = executeParallelTranslations(
-                    savedMessage.getId(), savedMessage.getContent(), recipientsByLang.keySet()
-            );
-
+            Map<String, String> translatedContentsMap = new HashMap<>();
+            if (savedMessage.getMessageType() == MessageType.TEXT) {
+                // ★ 핵심: 텍스트일 때만 번역기 가동
+                translatedContentsMap = executeParallelTranslations(
+                        savedMessage.getId(), savedMessage.getContent(), recipientsByLang.keySet()
+                );
+            }
             // 6. [핵심] 그룹별 비동기 발송 (Async Dispatch)
             executeParallelDispatch(
                     recipientsByLang, translatedContentsMap, savedMessage, userImageUrl
@@ -227,8 +229,8 @@ public class ChatMessageService {
                     sender.getFirstName(),
                     sender.getLastName(),
                     userImageUrl,
-                    MessageType.TEXT
-            );
+                    savedMessage.getMessageType()
+                    );
 
             CompletableFuture<Void> future = CompletableFuture.runAsync(() ->
                     chatSummaryService.sendSummaryToRecipientsInNewTx(messageResponse, recipientIds)
@@ -277,15 +279,21 @@ public class ChatMessageService {
         final Map<Long, String> finalProfileMap = profileMap;
         if (needsTranslation && targetLanguage != null && !targetLanguage.isEmpty()) {
 
-            Map<Long, String> translatedMap = chatTranslationService.getTranslatedMessages(messages, targetLanguage);
+            List<ChatMessage> textMessages = messages.stream()
+                    .filter(msg -> msg.getMessageType() == MessageType.TEXT)
+                    .toList();
+
+            Map<Long, String> translatedMap = chatTranslationService.getTranslatedMessages(textMessages, targetLanguage);
 
             return messages.stream()
                     .map(message -> {
-                        String translatedContent = translatedMap.get(message.getId());
+                        String translatedContent = (message.getMessageType() == MessageType.TEXT)
+                                ? translatedMap.get(message.getId())
+                                : null;
+
                         return mapToResponse(message, translatedContent, finalProfileMap);
                     })
                     .collect(Collectors.toList());
-
         } else {
             return messages.stream()
                     .map(message -> mapToResponse(message, null, finalProfileMap))

--- a/src/main/java/core/domain/user/service/UserService.java
+++ b/src/main/java/core/domain/user/service/UserService.java
@@ -131,6 +131,7 @@ public class UserService {
         Long userId = jwtTokenProvider.getUserIdFromRefreshToken(refreshToken);
         User user = userRepository.getUserById(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+        log.info("---  사용자 ID: {} {} {}  ---", user.getId(),user.getFirstName(),user.getLastName());
 
         String storedRefreshToken = redisService.getRefreshToken(userId);
 

--- a/src/main/resources/db/migration/V202512162325__Create_chat_message_translation.sql
+++ b/src/main/resources/db/migration/V202512162325__Create_chat_message_translation.sql
@@ -1,0 +1,20 @@
+CREATE TABLE chat_message_translation (
+                                          translation_id  BIGSERIAL       NOT NULL,
+                                          message_id      BIGINT          NOT NULL,
+                                          language_code   VARCHAR(10)     NOT NULL,
+                                          content         TEXT            NOT NULL,
+                                          created_at      TIMESTAMP(6),
+
+                                          PRIMARY KEY (translation_id)
+);
+
+ALTER TABLE chat_message_translation
+    ADD CONSTRAINT uk_message_lang UNIQUE (message_id, language_code);
+
+CREATE INDEX idx_message_id ON chat_message_translation (message_id);
+
+
+ALTER TABLE chat_message_translation
+    ADD CONSTRAINT fk_chat_message_translation_message_id
+        FOREIGN KEY (message_id)
+            REFERENCES chat_message (message_id) ON DELETE CASCADE;


### PR DESCRIPTION
# 📄 PR 변경사항
채팅방 마지막 메시지 동기화 오류 수정: 메시지 전송 시(a->b->c), 채팅방 목록에 최신 메시지(c)가 아닌 직전 메시지(b)가 표시되는 문제 해결
단순 입장 시 불필요한 소켓 응답 제거: 채팅방에 진입(조회)만 해도 읽음 처리 로직에 의해 소켓 이벤트가 발생하여, 프론트엔드에서 채팅방 목록 정렬이 섞이는 문제 수정
미사용 API 정리: 프론트엔드 팀과 크로스 체크 후 사용하지 않는 레거시 API 삭제
미디어 전송 하위 호환성 확보: 사진/동영상 전송 기능이 앱의 구버전과 신버전 모두에서 정상 동작하도록 로직 조정



# 🖌️ 구체적인 구현 내용
<!--  어떤 점을 고려하여 구현하였는지, 어떤 예외를 던지는지 등의 내용을 알려주세요! -->
- 

# ✨개선 사항 및 참고 사항
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 


# 💯 테스트
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 

# 확인
- [ ] 주석 및 print를 제거하셨나요?
- [ ] javaDoc을 작성하셨나요?
- [ ] merge할 브랜치와 로컬에서 merge 하셨나요?
- [ ] 더 수정할 작업은 없는지 확인하셨나요?
