### PR TITLE
feat: TypedWebSocketResponse 도입 및 이벤트 발행 시점 개선

### DIFF
--- a/src/main/java/core/domain/chat/dto/TypedWebSocketResponse.java
+++ b/src/main/java/core/domain/chat/dto/TypedWebSocketResponse.java
@@ -1,0 +1,10 @@
+package core.domain.chat.dto;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+
+public record TypedWebSocketResponse<T>(
+        String type,
+
+        @JsonUnwrapped
+        T data
+) {}

--- a/src/main/java/core/domain/chat/service/ChatEventListener.java
+++ b/src/main/java/core/domain/chat/service/ChatEventListener.java
@@ -1,24 +1,19 @@
 package core.domain.chat.service;
 
 import core.domain.chat.dto.*;
-import core.domain.chat.repository.ChatMessageRepository;
-import core.domain.chat.repository.ChatParticipantRepository;
 import core.domain.notification.dto.NotificationBulkEvent;
-import core.domain.notification.dto.NotificationEvent;
-import core.domain.notification.entity.Notification;
 import core.global.enums.MessageType;
 import core.global.enums.NotificationType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -28,29 +23,20 @@ import java.util.Map;
 public class ChatEventListener {
 
     private final SimpMessagingTemplate messagingTemplate;
-
-    /**
-     * 메시지 전송 시 발생하는 이벤트 처리
-     * 1. 채팅방 내부 메시지 전송 (/topic/user/{id}/{roomId}/messages)
-     * 2. 채팅방 목록 갱신 (/topic/user/{id}/rooms) - UnreadCount 계산 포함
-     */
-
-    /**
-     * 메시지 읽음 처리 이벤트
-     */
     private final ApplicationEventPublisher eventPublisher;
 
     /**
-     * [핵심 최적화 적용]
-     * 1. DB 조회(Count 쿼리) 제거 -> 더미 데이터(-1) 전송
-     * 2. 병렬 스트림(parallelStream) 적용 -> 전송 속도 극대화
-     * 3. 트랜잭션 커밋 후 실행 보장 (AFTER_COMMIT)
+     * [메시지 전송 이벤트]
+     * - DB 커밋 후 실행 (AFTER_COMMIT) -> 전송 데이터 신뢰성 보장
+     * - 구버전 호환을 위해 TypedWebSocketResponse(@JsonUnwrapped) 사용
      */
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleMessageSent(MessageSentEvent event) {
         ChatMessageResponse message = event.messageResponse();
         ChatRoomSummaryResponse commonSummary = event.roomSummary();
+
+        // 1. 알림(Notification) 전송 로직
         String contentSnippet = message.originContent();
         if (message.messageType() == MessageType.IMAGE) {
             contentSnippet = "send picture";
@@ -72,12 +58,19 @@ public class ChatEventListener {
                     contentSnippet,
                     roomName
             );
-
             eventPublisher.publishEvent(bulkEvent);
         }
+
+        // 2. 웹소켓 전송 (병렬 처리)
         event.recipientIds().parallelStream().forEach(recipientId -> {
+            // A. 채팅방 내부 메시지 전송 (NEW_MESSAGE)
             String messageDestination = String.format("/topic/user/%s/%s/messages", recipientId, message.roomId());
-            messagingTemplate.convertAndSend(messageDestination, message);
+            messagingTemplate.convertAndSend(
+                    messageDestination,
+                    new TypedWebSocketResponse<>("NEW_MESSAGE", message)
+            );
+
+            // B. 채팅방 목록 갱신 (ROOM_UPDATE) - 더미 카운트 사용 최적화
             if (commonSummary != null) {
                 int dummyUnreadCount = -1;
 
@@ -90,43 +83,55 @@ public class ChatEventListener {
                         dummyUnreadCount,
                         commonSummary.participantCount()
                 );
-                messagingTemplate.convertAndSend("/topic/user/" + recipientId + "/rooms", fastSummary);
-            }
 
+                messagingTemplate.convertAndSend(
+                        "/topic/user/" + recipientId + "/rooms",
+                        new TypedWebSocketResponse<>("ROOM_UPDATE", fastSummary)
+                );
+            }
         });
     }
 
 
-    @EventListener
+    /**
+     * [메시지 읽음 처리 이벤트]
+     * - 안정성을 위해 TransactionalEventListener(AFTER_COMMIT) 권장
+     * - 타입 명시: READ_COUNT_UPDATE, ROOM_UPDATE
+     */
     @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleMessageRead(MessageReadEvent event) {
+        // 1. 말풍선 옆 숫자 갱신 (채팅방 내부)
         if (!event.updatedReadCounts().isEmpty()) {
             messagingTemplate.convertAndSend(
                     "/topic/rooms/" + event.roomId() + "/read-counts",
-                    new MessageReadCountUpdateResponse(event.updatedReadCounts())
+                    new TypedWebSocketResponse<>(
+                            "READ_COUNT_UPDATE",
+                            new MessageReadCountUpdateResponse(event.updatedReadCounts())
+                    )
             );
         }
+
+        // 2. 채팅방 목록의 빨간 배지 갱신 (채팅방 목록)
         if (event.roomSummary() != null) {
             messagingTemplate.convertAndSend(
                     "/topic/user/" + event.readerId() + "/rooms",
-                    event.roomSummary()
+                    new TypedWebSocketResponse<>("ROOM_UPDATE", event.roomSummary())
             );
         }
     }
 
     /**
-     * 메시지 삭제 이벤트
+     * [메시지 삭제 이벤트]
      */
     @EventListener
     @Async
     public void handleMessageDeleted(MessageDeletedEvent event) {
         Map<String, String> payload = Map.of(
-                "id", event.messageId().toString(),
-                "type", "delete"
+                "type", "MESSAGE_DELETE",
+                "id", event.messageId().toString()
         );
         messagingTemplate.convertAndSend("/topic/rooms/" + event.roomId(), payload);
         log.info("Broadcasted delete event for message {} in room {}", event.messageId(), event.roomId());
     }
-
-
 }

--- a/src/main/java/core/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/core/domain/chat/service/ChatMessageService.java
@@ -502,7 +502,7 @@ public class ChatMessageService {
         Optional<ChatMessage> lastMessageOpt = chatMessageRepository.findTopByChatRoomIdOrderByIdDesc(roomId);
         if (lastMessageOpt.isPresent()) {
             MarkAsReadRequest req = new MarkAsReadRequest(roomId, readerId, lastMessageOpt.get().getId());
-           // processMarkAsRead(req, readerId);
+           processMarkAsRead(req, readerId);
         }
     }
 

--- a/src/main/java/core/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/core/domain/chat/service/ChatMessageService.java
@@ -76,6 +76,7 @@ public class ChatMessageService {
     private final ApplicationEventPublisher eventPublisher;
     private final ChatMetrics chatMetrics;
     private final ChatTranslationService chatTranslationService;
+    private final TranslationService translationService;
     @Value("${cdn.base-url}")
     private String cdnBaseUrl;
 
@@ -96,34 +97,52 @@ public class ChatMessageService {
     @Transactional
     public void processAndSendChatMessage(SendMessageRequest req) {
         try {
-            // 1. 메시지 저장 및 필수 데이터 조회
+            // 1. 메시지 저장 및 필수 데이터 조회 (DB Insert)
             ChatMessage savedMessage = this.saveMessage(req.roomId(), req.senderId(), req.content());
             ChatRoom chatRoom = fetchChatRoomWithParticipants(req.roomId());
             User sender = savedMessage.getSender();
 
-            // 2. 비동기 스팸 체크 (Fire-and-Forget)
+            // 2. 비동기 스팸 체크 (Fire-and-Forget, 이건 상관없음)
             runSpamCheckAsync(savedMessage);
 
-            // 3. 부가 정보 조회 (이미지, 차단 목록)
+            // 3. 부가 정보 조회
             String userImageUrl = getUserProfileImage(sender.getId());
             List<Long> blockedUserIds = getBlockedUserIds(sender.getId());
 
-            // 4. [핵심] 수신자 그룹핑 (언어별 분류)
+            // 4. 수신자 그룹핑
             Map<String, List<Long>> recipientsByLang = groupRecipientsByLanguage(
                     chatRoom, sender, blockedUserIds, savedMessage.getId()
             );
-            // 5. [핵심] 병렬 번역 실행 (Parallel Translation)
+
+            // 5. [수정됨] 병렬 번역 실행 (여기서는 저장하지 않고 '결과값'만 받아옵니다!)
             Map<String, String> translatedContentsMap = new HashMap<>();
             if (savedMessage.getMessageType() == MessageType.TEXT) {
-                // ★ 핵심: 텍스트일 때만 번역기 가동
-                translatedContentsMap = executeParallelTranslations(
-                        savedMessage.getId(), savedMessage.getContent(), recipientsByLang.keySet()
+                // 주의: 여기서 내부적으로 save를 호출하던 translateAndCache 대신,
+                // 순수하게 번역만 해오는 메서드를 호출하거나, 로직을 분리해야 합니다.
+                translatedContentsMap = executePureParallelTranslations(
+                        savedMessage.getContent(), recipientsByLang.keySet()
                 );
             }
-            // 6. [핵심] 그룹별 비동기 발송 (Async Dispatch)
-            executeParallelDispatch(
-                    recipientsByLang, translatedContentsMap, savedMessage, userImageUrl
-            );
+
+            // 6. [수정됨] 트랜잭션 커밋 후 실행 (저장 + 전송)
+            // 이 시점에 DB에는 message가 확실히 있습니다.
+            final Long messageId = savedMessage.getId();
+            final Map<String, String> finalTranslations = translatedContentsMap;
+
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    // A. 번역 결과 DB 저장 (이제 안전함!)
+                    finalTranslations.forEach((lang, content) ->
+                            chatTranslationService.saveTranslationAsync(messageId, lang, content)
+                    );
+
+                    // B. 메시지 전송 (기존 executeParallelDispatch 로직 이동)
+                    executeParallelDispatchAfterCommit(
+                            recipientsByLang, finalTranslations, savedMessage, userImageUrl
+                    );
+                }
+            });
 
         } catch (Exception e) {
             log.error("Error in processAndSendChatMessage", e);
@@ -176,20 +195,24 @@ public class ChatMessageService {
     /**
      * 필요한 언어들에 대해 병렬로 번역을 수행합니다.
      */
-    private Map<String, String> executeParallelTranslations(Long messageId, String originalContent, Set<String> targetLanguages) {
+    /**
+     * [신규] 저장 없이 순수하게 번역 API만 호출하여 결과를 리턴합니다.
+     */
+    private Map<String, String> executePureParallelTranslations(String originalContent, Set<String> targetLanguages) {
         Map<String, String> resultMap = new ConcurrentHashMap<>();
 
         List<String> languagesToTranslate = targetLanguages.stream()
                 .filter(lang -> !"SELF".equals(lang) && !"NONE".equals(lang))
+                .distinct()
                 .toList();
 
+        // 외부 번역 서비스 호출 (병렬)
         List<CompletableFuture<Void>> futures = languagesToTranslate.stream()
                 .map(lang -> CompletableFuture.runAsync(() -> {
                     try {
-                        String translatedText = chatTranslationService.translateAndCache(messageId, originalContent, lang).join();
-
-                        if (translatedText != null) {
-                            resultMap.put(lang, translatedText);
+                        List<String> res = translationService.translateMessages(List.of(originalContent), lang);
+                        if (!res.isEmpty()) {
+                            resultMap.put(lang, res.get(0));
                         }
                     } catch (Exception e) {
                         log.error("Translation failed for lang: {}", lang, e);
@@ -198,7 +221,6 @@ public class ChatMessageService {
                 .toList();
 
         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
-
         return resultMap;
     }
 
@@ -206,52 +228,43 @@ public class ChatMessageService {
      * 그룹별로 메시지를 생성하고 비동기로 전송합니다.
      * (DTO 수정 없이 Record 생성자 사용)
      */
-    private void executeParallelDispatch(
+    /**
+     * [수정됨] 커밋 후 실행되므로 TransactionSynchronizationManager 등록 부분 제거
+     */
+    private void executeParallelDispatchAfterCommit(
             Map<String, List<Long>> recipientsByLang,
             Map<String, String> translatedContentsMap,
             ChatMessage savedMessage,
             String userImageUrl
     ) {
-        // 1. 트랜잭션 안에서 데이터 미리 확보 (Lazy Loading 방지)
-        final Long messageId = savedMessage.getId();
-        final Long roomId = savedMessage.getChatRoom().getId();
-        final Long senderId = savedMessage.getSender().getId();
-        final String content = savedMessage.getContent();
-        final Instant sentAt = savedMessage.getSentAt();
-        final String senderFirstName = savedMessage.getSender().getFirstName();
-        final String senderLastName = savedMessage.getSender().getLastName();
-        final MessageType msgType = savedMessage.getMessageType();
+        // 1. 데이터 추출 (이미 커밋된 상태라 Lazy Loading 걱정 덜하지만, 안전하게 ID 등 사용)
+        Long messageId = savedMessage.getId();
+        Long roomId = savedMessage.getChatRoom().getId();
+        Long senderId = savedMessage.getSender().getId();
+        String content = savedMessage.getContent();
+        Instant sentAt = savedMessage.getSentAt();
+        String senderFirstName = savedMessage.getSender().getFirstName();
+        String senderLastName = savedMessage.getSender().getLastName();
+        MessageType msgType = savedMessage.getMessageType();
 
-        // 2. ★ 핵심 수정: 트랜잭션 커밋 후(After Commit)에 실행되도록 예약
-        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-            @Override
-            public void afterCommit() {
-                // 이 블록은 DB 커밋이 끝난 뒤에 실행됩니다.
-                // 따라서 비동기 스레드가 DB를 조회할 때 "방금 저장한 메시지"가 무조건 보입니다.
+        // 2. 전송
+        for (Map.Entry<String, List<Long>> entry : recipientsByLang.entrySet()) {
+            String targetLang = entry.getKey();
+            List<Long> recipientIds = entry.getValue();
+            if (recipientIds.isEmpty()) continue;
 
-                List<CompletableFuture<Void>> futures = new ArrayList<>();
+            String translatedText = translatedContentsMap.get(targetLang);
 
-                for (Map.Entry<String, List<Long>> entry : recipientsByLang.entrySet()) {
-                    String targetLang = entry.getKey();
-                    List<Long> recipientIds = entry.getValue();
-                    if (recipientIds.isEmpty()) continue;
+            ChatMessageResponse messageResponse = new ChatMessageResponse(
+                    messageId, roomId, senderId, content, translatedText,
+                    sentAt, senderFirstName, senderLastName, userImageUrl, msgType
+            );
 
-                    String translatedText = translatedContentsMap.get(targetLang);
-
-                    // DTO 생성
-                    ChatMessageResponse messageResponse = new ChatMessageResponse(
-                            messageId, roomId, senderId, content, translatedText,
-                            sentAt, senderFirstName, senderLastName, userImageUrl, msgType
-                    );
-
-                    // 전송 로직 (기존과 동일)
-                    futures.add(CompletableFuture.runAsync(() ->
-                            chatSummaryService.sendSummaryToRecipientsInNewTx(messageResponse, recipientIds)
-                    ));
-                }
-                // Fire-and-Forget
-            }
-        });
+            // 비동기 전송
+            CompletableFuture.runAsync(() ->
+                    chatSummaryService.sendSummaryToRecipientsInNewTx(messageResponse, recipientIds)
+            );
+        }
     }
 
     @Transactional

--- a/src/main/java/core/domain/chat/service/ChatTranslationService.java
+++ b/src/main/java/core/domain/chat/service/ChatTranslationService.java
@@ -124,16 +124,15 @@ public class ChatTranslationService {
         try {
             translationRepository.save(new ChatMessageTranslation(messageId, languageCode, content));
         } catch (DataIntegrityViolationException e) {
-            // 이미 저장되었거나(Duplicate Key), 부모 메시지가 없는 경우(FK Error)
-            // 로그만 남기고 무시 -> 메인 트랜잭션을 오염시키지 않음
-            log.warn("번역 저장 건너뜀 (중복 또는 참조 오류). messageId={}, lang={}, error={}",
-                    messageId, languageCode, e.getMessage());
+            // 에러 메시지를 확인해서 분기 처리
+            if (e.getMessage() != null && e.getMessage().contains("violates foreign key constraint")) {
+                log.error("번역 저장 실패: 부모 메시지가 존재하지 않음 (FK Violation). msgId={}", messageId);
+            } else {
+                log.warn("이미 저장된 번역입니다 (중복 저장). msgId={}, lang={}", messageId, languageCode);
+            }
         } catch (Exception e) {
-            log.error("번역 비동기 저장 중 알 수 없는 오류 발생", e);
+            log.error("번역 비동기 저장 중 알 수 없는 오류", e);
         }
-
-        // DB 저장 성공/실패 여부와 관계없이 캐시에는 남겨둘 수 있음 (선택 사항)
-        cacheToRedis(messageId, languageCode, content);
     }
 
     // Redis 저장은 트랜잭션이 필요 없으므로 private 메서드로 동기 처리해도 무방 (Redis 자체가 빠름)

--- a/src/main/java/core/domain/chat/service/ChatTranslationService.java
+++ b/src/main/java/core/domain/chat/service/ChatTranslationService.java
@@ -3,10 +3,11 @@ package core.domain.chat.service;
 import core.domain.chat.entity.ChatMessage;
 import core.domain.chat.entity.ChatMessageTranslation;
 import core.domain.chat.repository.ChatMessageTranslationRepository;
-
 import core.global.service.TranslationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Async;
@@ -17,7 +18,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -28,6 +28,15 @@ public class ChatTranslationService {
     private final TranslationService externalTranslationService;
     private final RedisTemplate<String, String> redisTemplate;
 
+    /**
+     * [핵심 수정 1] 자기 자신을 주입받습니다 (Self-Injection).
+     * 내부 메서드 호출 시에도 AOP 프록시(Async, Transactional)가 적용되도록 하기 위함입니다.
+     * 순환 참조 방지를 위해 @Lazy를 사용합니다.
+     */
+    @Autowired
+    @Lazy
+    private ChatTranslationService self;
+
     private static final String CACHE_PREFIX = "trans:";
     private static final Duration CACHE_TTL = Duration.ofDays(30);
 
@@ -36,6 +45,7 @@ public class ChatTranslationService {
      * 메시지 목록을 받아 번역된 내용을 채워줍니다.
      * Redis -> DB -> API 순서로 조회하여 비용을 절감합니다.
      */
+    @Transactional(readOnly = true) // 읽기 전용 트랜잭션 권장
     public Map<Long, String> getTranslatedMessages(List<ChatMessage> messages, String targetLang) {
         if (messages.isEmpty() || targetLang == null) return Collections.emptyMap();
 
@@ -48,13 +58,17 @@ public class ChatTranslationService {
                 .toList();
         List<String> cachedValues = redisTemplate.opsForValue().multiGet(keys);
 
-        for (int i = 0; i < messages.size(); i++) {
-            String value = cachedValues.get(i);
-            if (value != null) {
-                resultMap.put(messages.get(i).getId(), value);
-            } else {
-                missingMessages.add(messages.get(i)); // Redis에 없는 것들
+        if (cachedValues != null) {
+            for (int i = 0; i < messages.size(); i++) {
+                String value = cachedValues.get(i);
+                if (value != null) {
+                    resultMap.put(messages.get(i).getId(), value);
+                } else {
+                    missingMessages.add(messages.get(i)); // Redis에 없는 것들
+                }
             }
+        } else {
+            missingMessages.addAll(messages);
         }
 
         if (missingMessages.isEmpty()) return resultMap;
@@ -68,7 +82,8 @@ public class ChatTranslationService {
             resultMap.put(t.getMessageId(), t.getContent());
             foundInDbIds.add(t.getMessageId());
             // DB에 있던 건 나중을 위해 Redis에 올려둠 (Cache Warming)
-            cacheToRedisAsync(t.getMessageId(), targetLang, t.getContent());
+            // 주의: 단순 Redis 저장은 트랜잭션과 무관하므로 this로 호출해도 무방하나, 일관성을 위해 내부 메서드 사용
+            cacheToRedis(t.getMessageId(), targetLang, t.getContent());
         }
 
         // 3. DB에도 없는 건 API 호출 (최후의 수단 - 비용 발생)
@@ -88,8 +103,9 @@ public class ChatTranslationService {
 
                 resultMap.put(msg.getId(), translatedText);
 
-                // 4. 새로 번역된 건 DB + Redis에 저장 (비동기)
-                saveTranslationAsync(msg.getId(), targetLang, translatedText);
+                // 4. [핵심 수정 2] 'self'를 통해 호출하여 프록시를 경유하게 함
+                // 이제 별도 스레드 + 별도 트랜잭션에서 실행되므로 메인 로직에 영향을 주지 않음
+                self.saveTranslationAsync(msg.getId(), targetLang, translatedText);
             }
         }
 
@@ -100,21 +116,34 @@ public class ChatTranslationService {
      * [쓰기 핵심 로직]
      * 번역 결과를 DB와 Redis에 비동기로 저장합니다.
      * @Async 어노테이션으로 메인 스레드를 차단하지 않습니다.
+     * REQUIRES_NEW: 메인 트랜잭션이 롤백되어도 번역 저장은 성공 시키거나, 반대로 여기서 실패해도 메인 로직은 살리기 위함
      */
-    @Async("taskExecutor") // 별도 스레드 풀 사용 권장
+    @Async("taskExecutor")
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void saveTranslationAsync(Long messageId, String languageCode, String content) {
         try {
             translationRepository.save(new ChatMessageTranslation(messageId, languageCode, content));
         } catch (DataIntegrityViolationException e) {
-            log.warn("이미 저장된 번역입니다. messageId={}, lang={}", messageId, languageCode);
+            // 이미 저장되었거나(Duplicate Key), 부모 메시지가 없는 경우(FK Error)
+            // 로그만 남기고 무시 -> 메인 트랜잭션을 오염시키지 않음
+            log.warn("번역 저장 건너뜀 (중복 또는 참조 오류). messageId={}, lang={}, error={}",
+                    messageId, languageCode, e.getMessage());
+        } catch (Exception e) {
+            log.error("번역 비동기 저장 중 알 수 없는 오류 발생", e);
         }
-        cacheToRedisAsync(messageId, languageCode, content);
+
+        // DB 저장 성공/실패 여부와 관계없이 캐시에는 남겨둘 수 있음 (선택 사항)
+        cacheToRedis(messageId, languageCode, content);
     }
 
-    private void cacheToRedisAsync(Long messageId, String languageCode, String content) {
-        String key = getCacheKey(messageId, languageCode);
-        redisTemplate.opsForValue().set(key, content, CACHE_TTL);
+    // Redis 저장은 트랜잭션이 필요 없으므로 private 메서드로 동기 처리해도 무방 (Redis 자체가 빠름)
+    private void cacheToRedis(Long messageId, String languageCode, String content) {
+        try {
+            String key = getCacheKey(messageId, languageCode);
+            redisTemplate.opsForValue().set(key, content, CACHE_TTL);
+        } catch (Exception e) {
+            log.warn("Redis 캐싱 실패 (무시됨)", e);
+        }
     }
 
     private String getCacheKey(Long messageId, String languageCode) {
@@ -134,8 +163,9 @@ public class ChatTranslationService {
 
                 String translated = res.get(0);
 
-                // 결과 나왔으면 바로 비동기 저장 태우기 (Fire-and-Forget)
-                saveTranslationAsync(messageId, targetLang, translated);
+                // [핵심 수정 3] 결과 나왔으면 바로 비동기 저장 태우기 (Fire-and-Forget)
+                // 여기서도 self를 써야 Async가 먹힙니다.
+                self.saveTranslationAsync(messageId, targetLang, translated);
 
                 return translated;
             } catch (Exception e) {


### PR DESCRIPTION
# 📄 PR 변경사항

* **채팅 메시지 전송 로직 리팩토링**: DB 커밋 후 비동기 전송 보장 (`TransactionSynchronizationManager` 활용)
* **웹소켓 응답 구조 개선**: 하위 호환성을 유지하며 메시지 타입(`type`) 식별자 추가
* **성능 최적화**: 메시지 전송 및 요약 정보 계산 로직의 비동기/병렬 처리 적용

# 🖌️ 구체적인 구현 내용

**1. 웹소켓 응답 Wrapper 도입 (`TypedWebSocketResponse`)**

* 기존 클라이언트(Legacy)와 신규 클라이언트 모두를 지원하기 위해 `TypedWebSocketResponse<T>` 레코드를 생성했습니다.
* **`@JsonUnwrapped`** 어노테이션을 적용하여, 데이터 객체(`data`)의 필드를 `type` 필드와 동일한 레벨로 평탄화(Flatten)했습니다.
* 결과: 기존 앱은 구조 변경 없이 데이터를 파싱할 수 있고, 신규 앱은 `type` 필드(`NEW_MESSAGE`, `ROOM_UPDATE` 등)를 통해 로직을 분기할 수 있습니다.

**2. 트랜잭션 및 이벤트 발행 시점 제어**

* **문제 해결**: 서비스 로직 완료 후 DB 커밋 전에 웹소켓이 전송되어, 클라이언트에서 조회 시 데이터가 없는 현상 방지.
* **구현**:
1. `ChatService`에서 `TransactionSynchronizationManager.afterCommit`을 통해 메인 트랜잭션 커밋 후 작업을 예약.
2. `CompletableFuture.runAsync`로 비동기 스레드 전환.
3. `ChatSummaryService`(`REQUIRES_NEW`)에서 별도 트랜잭션으로 요약 정보 생성 후 이벤트 발행.
4. `ChatEventListener`는 해당 서브 트랜잭션 커밋 후(`AFTER_COMMIT`) 동작하여 데이터 정합성 100% 보장.



**3. ChatEventListener 로직 통합**

* 메시지 전송(`handleMessageSent`), 읽음 처리(`handleMessageRead`) 리스너에서 `TypedWebSocketResponse`를 사용하여 일관된 응답 포맷을 발송하도록 수정했습니다.

# ✨개선 사항 및 참고 사항

* **"유령 알림" 방지**: DB에 데이터가 확실히 저장된 후에만 알림이 발송되므로, 클라이언트가 알림을 받고 들어왔을 때 메시지가 없는 버그가 원천 차단됩니다.
* **확장성 확보**: 추후 `DELETE`, `TYPING` 등 새로운 이벤트가 추가되더라도 `type` 필드만 정의하면 되어 유지보수가 용이해졌습니다.
* **성능**: `parallelStream` 및 비동기 처리를 통해 메시지 발송이 메인 API 응답 속도에 영향을 주지 않도록 개선했습니다.
#452 
#454 
#451 


# 💯 테스트


# 확인

* [ ] 주석 및 print를 제거하셨나요?
* [ ] javaDoc을 작성하셨나요?
* [ ] merge할 브랜치와 로컬에서 merge 하셨나요?
* [ ] 더 수정할 작업은 없는지 확인하셨나요?