### PR TITLE
Revert "Fix/chat error"

### DIFF
--- a/src/main/java/core/domain/chat/controller/ChatMemberController.java
+++ b/src/main/java/core/domain/chat/controller/ChatMemberController.java
@@ -104,6 +104,8 @@ public class ChatMemberController {
             @AuthenticationPrincipal CustomUserDetails principal
     ) {
         Long userId = principal.getUserId();
+        log.info("👉 [API Request] 번역 설정 변경 요청 | RoomId: {}, UserId: {}, 요청값(Enable): {}",
+                roomId, userId, request.translateEnabled());
         chatService.toggleTranslation(roomId, userId, request.translateEnabled());
         return ResponseEntity.ok(ApiResponse.success(null));
     }

--- a/src/main/java/core/domain/chat/entity/ChatParticipant.java
+++ b/src/main/java/core/domain/chat/entity/ChatParticipant.java
@@ -59,7 +59,6 @@ public class ChatParticipant {
         this.status = ChatParticipantStatus.ACTIVE;
         this.joinedAt = Instant.now();
         this.notificationsEnabled = true;
-        this.translateEnabled = true;
     }
     public void delete() {
         this.status = ChatParticipantStatus.LEFT;

--- a/src/main/java/core/domain/chat/service/ChatEventListener.java
+++ b/src/main/java/core/domain/chat/service/ChatEventListener.java
@@ -72,6 +72,7 @@ public class ChatEventListener {
 
             // B. 채팅방 목록 갱신 (ROOM_UPDATE) - 더미 카운트 사용 최적화
             if (commonSummary != null) {
+                int dummyUnreadCount = -1;
 
                 ChatRoomSummaryResponse fastSummary = new ChatRoomSummaryResponse(
                         commonSummary.roomId(),
@@ -79,7 +80,7 @@ public class ChatEventListener {
                         commonSummary.lastMessageContent(),
                         commonSummary.lastMessageTime(),
                         commonSummary.roomImageUrl(),
-                        commonSummary.unreadCount(),
+                        dummyUnreadCount,
                         commonSummary.participantCount()
                 );
 

--- a/src/main/java/core/domain/chat/service/ChatMemberService.java
+++ b/src/main/java/core/domain/chat/service/ChatMemberService.java
@@ -139,7 +139,10 @@ public class ChatMemberService {
     public void toggleTranslation(Long roomId, Long userId, boolean enable) {
         ChatParticipant participant = chatParticipantRepository.findByChatRoomIdAndUserId(roomId, userId)
                 .orElseThrow(() -> new BusinessException(ChatErrorCode.NOT_CHAT_PARTICIPANT));
+        boolean previousState = participant.isTranslateEnabled();
         participant.toggleTranslation(enable);
+        log.info("✅ [Service] 번역 기능 변경 완료 | RoomId: {}, UserId: {} | 상태변경: {} -> {}",
+                roomId, userId, previousState, enable);
         chatParticipantRepository.save(participant);
     }
 

--- a/src/main/java/core/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/core/domain/chat/service/ChatMessageService.java
@@ -17,9 +17,7 @@ import core.global.entity.image.dto.ImageModerationEvent;
 import core.global.entity.image.entity.Image;
 import core.global.entity.image.repository.ImageRepository;
 import core.global.entity.image.service.impl.S3ImageStorageClient;
-import core.global.entity.image.service.impl.S3ImageStorageClient;
 import core.global.enums.ChatParticipantStatus;
-import core.global.enums.ImageModerationStatus;
 import core.global.enums.ImageType;
 import core.global.enums.MessageType;
 import core.global.enums.errorcode.ChatErrorCode;
@@ -42,7 +40,6 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
-import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
@@ -50,12 +47,10 @@ import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignReques
 
 import java.time.Duration;
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 @Service
 @Slf4j
@@ -113,15 +108,12 @@ public class ChatMessageService {
 
             // 2. 비동기 스팸 체크 (Fire-and-Forget, 이건 상관없음)
             runSpamCheckAsync(savedMessage);
-            //3. 채팅방 1대1 채팅방이면 상대방 재참여 시킴
-            if (Boolean.FALSE.equals(chatRoom.getIsGroup())) {
-                reviveParticipantsIfDm(chatRoom);
-            }
-            // 4. 부가 정보 조회
+
+            // 3. 부가 정보 조회
             String userImageUrl = getUserProfileImage(sender.getId());
             List<Long> blockedUserIds = getBlockedUserIds(sender.getId());
 
-            // 5. 수신자 그룹핑
+            // 4. 수신자 그룹핑
             Map<String, List<Long>> recipientsByLang = groupRecipientsByLanguage(
                     chatRoom, sender, blockedUserIds, savedMessage.getId()
             );
@@ -129,7 +121,7 @@ public class ChatMessageService {
             List<Long> allRecipientIds = getAllRecipientIds(recipientsByLang);
             ChatMessageResponse savedMessageResponse = buildBaseMessageResponse(savedMessage, userImageUrl);
 
-            // 6. [수정됨] 병렬 번역 실행 (여기서는 저장하지 않고 '결과값'만 받아옵니다!)
+            // 5. [수정됨] 병렬 번역 실행 (여기서는 저장하지 않고 '결과값'만 받아옵니다!)
             Map<String, String> translatedContentsMap = new HashMap<>();
             if (savedMessage.getMessageType() == MessageType.TEXT) {
                 // 주의: 여기서 내부적으로 save를 호출하던 translateAndCache 대신,
@@ -139,7 +131,7 @@ public class ChatMessageService {
                 );
             }
 
-            // 7. [수정됨] 트랜잭션 커밋 후 실행 (저장 + 전송)
+            // 6. [수정됨] 트랜잭션 커밋 후 실행 (저장 + 전송)
             // 이 시점에 DB에는 message가 확실히 있습니다.
             final Long messageId = savedMessage.getId();
             final Map<String, String> finalTranslations = translatedContentsMap;
@@ -168,18 +160,7 @@ public class ChatMessageService {
         }
     }
 
-    /**
-     * 1:1 채팅방인 경우, 나간 상태(LEFT)인 참여자를 다시 참여(ACTIVE) 상태로 변경합니다.
-     * ChatParticipant 엔티티의 reJoin() 편의 메서드를 사용합니다.
-     */
-    private void reviveParticipantsIfDm(ChatRoom chatRoom) {
-        for (ChatParticipant p : chatRoom.getParticipants()) {
-            if (p.getStatus() == ChatParticipantStatus.ACTIVE) {
-                continue;
-            }
-            p.reJoin();
-        }
-    }
+
     private ChatRoom fetchChatRoomWithParticipants(Long roomId) {
         return chatRoomRepository.findChatRoomWithParticipantsAndUsers(roomId)
                 .orElseThrow(() -> new BusinessException(ChatErrorCode.NOT_CHAT_PARTICIPANT));
@@ -231,12 +212,8 @@ public class ChatMessageService {
 
             if (blockedUserIds.contains(recipient.getId())) continue;
 
-            if (p.getStatus() != ChatParticipantStatus.ACTIVE) {
-                continue;
-            }
-
             if (recipient.getId().equals(sender.getId())) {
-                p.setLastReadMessageId(messageId);
+                p.setLastReadMessageId(messageId); // (자동 업데이트)
             }
 
 
@@ -334,8 +311,9 @@ public class ChatMessageService {
         }
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<ChatMessageResponse> getMessages(Long roomId, Long userId, Long lastMessageId) {
+        // 1. 참여자 검증
         ChatParticipant participant = chatParticipantRepository.findByChatRoomIdAndUserId(roomId, userId)
                 .orElseThrow(() -> new BusinessException(ChatErrorCode.NOT_CHAT_PARTICIPANT));
 
@@ -580,7 +558,7 @@ public class ChatMessageService {
                 .orElse(null);
 
         // 6-3. 텍스트 대체 문구 설정
-        String originContentText = (req.messageType() == MessageType.IMAGE) ? "image" : "video";
+        String originContentText = (req.messageType() == MessageType.IMAGE) ? "사진" : "동영상";
 
         // 6-4. DTO 생성 (Record 순서 주의)
         ChatMessageResponse messageResponse = new ChatMessageResponse(
@@ -758,7 +736,6 @@ public class ChatMessageService {
         // 4. 번역 처리
         Map<Long, String> translatedMap = Collections.emptyMap();
         if (participant.isTranslateEnabled() && participant.getUser().getTranslateLanguage() != null) {
-            // chatTranslationService가 Redis -> DB -> API 순서로 체크하고 저장까지 수행
             translatedMap = chatTranslationService.getTranslatedMessages(combined, participant.getUser().getTranslateLanguage());
         }
 

--- a/src/main/java/core/domain/chat/service/ChatTranslationService.java
+++ b/src/main/java/core/domain/chat/service/ChatTranslationService.java
@@ -128,7 +128,7 @@ public class ChatTranslationService {
             if (e.getMessage() != null && e.getMessage().contains("violates foreign key constraint")) {
                 log.error("번역 저장 실패: 부모 메시지가 존재하지 않음 (FK Violation). msgId={}", messageId);
             } else {
-                log.info("이미 저장된 번역입니다 (중복 저장). msgId={}, lang={}", messageId, languageCode);
+                log.warn("이미 저장된 번역입니다 (중복 저장). msgId={}, lang={}", messageId, languageCode);
             }
         } catch (Exception e) {
             log.error("번역 비동기 저장 중 알 수 없는 오류", e);

--- a/src/main/java/core/domain/notification/service/UserNotificationService.java
+++ b/src/main/java/core/domain/notification/service/UserNotificationService.java
@@ -9,7 +9,6 @@ import core.domain.userdevicetoken.entity.UserDeviceToken;
 import core.domain.userdevicetoken.repository.UserDeviceTokenRepository;
 import core.domain.usernotificationsetting.entity.UserNotificationSetting;
 import core.domain.usernotificationsetting.repository.UserNotificationSettingRepository;
-import core.global.enums.DeviceType;
 import core.global.enums.ImageType;
 import core.global.enums.NotificationType;
 import core.global.exception.BusinessException;
@@ -48,25 +47,20 @@ public class UserNotificationService {
     /**
      * FCM 기기 토큰을 등록하거나 갱신합니다. (람다 제거 버전)
      */
-    @Transactional // 삭제 로직이 들어가므로 트랜잭션 필수
     public void registerDeviceToken(Long userId, String deviceToken) {
         User user = findUserById(userId);
-        List<UserDeviceToken> tokens = userDeviceTokenRepository.findByDeviceToken(deviceToken);
 
-        if (tokens.isEmpty()) {
+        Optional<UserDeviceToken> optionalToken = userDeviceTokenRepository.findByDeviceToken(deviceToken);
+
+        if (optionalToken.isPresent()) {
+            UserDeviceToken existingToken = optionalToken.get();
+            existingToken.updateUser(user);
+        } else {
             UserDeviceToken newToken = new UserDeviceToken(user, deviceToken);
             userDeviceTokenRepository.save(newToken);
-
-        } else {
-            UserDeviceToken mainToken = tokens.get(0);
-            mainToken.updateUser(user);
-            if (tokens.size() > 1) {
-                for (int i = 1; i < tokens.size(); i++) {
-                    userDeviceTokenRepository.delete(tokens.get(i));
-                }
-            }
         }
     }
+
     /**
      * 사용자의 알림 설정 상태를 확인합니다. (이 메서드는 원래 람다를 사용하지 않았습니다)
      */

--- a/src/main/java/core/domain/userdevicetoken/repository/UserDeviceTokenRepository.java
+++ b/src/main/java/core/domain/userdevicetoken/repository/UserDeviceTokenRepository.java
@@ -16,7 +16,9 @@ import java.util.Optional;
 
 public interface UserDeviceTokenRepository extends JpaRepository<UserDeviceToken, Long> {
 
-    List<UserDeviceToken> findByDeviceToken(String deviceToken);
+    Optional<UserDeviceToken> findByDeviceToken(String deviceToken);
+
+    List<UserDeviceToken> findAllByUserId(Long id);
     void deleteAllByUserId(Long userId);
     List<UserDeviceToken> findAllByUser(User user);
 


### PR DESCRIPTION
# 📄 PR 변경사항
**채팅방 목록 요약 정보 조회 (ChatRoomSummaryResponse) 구현
안 읽은 메시지 개수(Unread Count) 산정 로직 구현
채팅방 번역 기능 설정 (toggleTranslation) 구현 및 트랜잭션 수정
디바이스 토큰 등록/갱신 (registerDeviceToken) 로직 안정화**


# 🖌️ 구체적인 구현 내용
**1. 채팅방 목록 요약 (buildChatRoomSummaryResponse)**
채팅방의 마지막 메시지 내용, 전송 시간, 상대방 정보(1:1인 경우) 또는 방 정보(그룹인 경우)를 조합하여 반환하도록 구현했습니다.
안 읽은 메시지 카운트 기준 정립:
같은 채팅방(roomId) + 내가 읽은 마지막 ID 이후(> lastReadId) + 내가 보낸 메시지 제외(sender != me) 조건으로 카운트합니다.

**2. 번역 설정 토글 (toggleTranslation)**
ChatParticipant의 translateEnabled 상태를 변경하는 API입니다.
Dirty Checking 미동작 이슈 해결: 상태 변경 후 DB 반영이 누락되는 현상을 방지하기 위해 @Transactional 적용 및 repository.save()를 명시적으로 호출하도록 수정했습니다.
요청 값과 변경 전/후 상태를 확인할 수 있는 로그를 추가했습니다.

**3. 디바이스 토큰 등록 (registerDeviceToken)**
기존 토큰이 있을 경우 유저 정보를 갱신하고, 없을 경우 신규 생성합니다.
번역 설정과 마찬가지로 업데이트 누락 방지를 위해 명시적 save() 호출 및 로그를 추가하여 데이터 정합성을 높였습니다.

- 

# ✨개선 사항 및 참고 사항
DB 반영 이슈 해결: JPA 변경 감지(Dirty Checking)에만 의존했을 때 발생했던 DB 미반영 문제를 해결하기 위해, 명시적 save()를 사용하여 안정성을 확보했습니다.

**해결 에러 이슈들**
#466 -> 현재 재현불가로 추후 재현가능시 해결 예정
#472 
#469 
#465 
#468 

- 


# 💯 테스트
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 

# 확인
- [ ] 주석 및 print를 제거하셨나요?
- [ ] javaDoc을 작성하셨나요?
- [ ] merge할 브랜치와 로컬에서 merge 하셨나요?
- [ ] 더 수정할 작업은 없는지 확인하셨나요?
