### PR TITLE
추천 시스템 로직 전면 개편 (활동성 강화 + 국적 매칭 도입)

### DIFF
--- a/src/main/java/core/domain/user/repository/UserRepository.java
+++ b/src/main/java/core/domain/user/repository/UserRepository.java
@@ -24,13 +24,28 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
 
     boolean existsByEmail(String email);
 
-    @Query("SELECT u FROM User u WHERE u.id NOT IN :excludeIds " +
-           "AND u.purpose IS NOT NULL AND u.purpose <> '' " +
-           "AND u.country IS NOT NULL AND u.country <> '' " +
-           "AND u.birthdate IS NOT NULL AND u.birthdate <> '' " +
-           "AND u.language IS NOT NULL AND u.language <> ''")
-    List<User> findFullProfiledRecommendationCandidates(@Param("excludeIds") Collection<Long> excludeIds);
+    @Query("SELECT u FROM User u " +
+            "WHERE u.id NOT IN :excludeIds " +
+            // [핵심] 최근 활동 시간 제한 (이게 있어야 답장률이 올라갑니다)
+            "AND u.lastSeenAt >= :limitTime " +
 
+            // [프로필 완성 조건] (빈 문자열이나 null이 아닌 경우)
+            "AND u.purpose IS NOT NULL AND u.purpose <> '' " +
+            "AND u.country IS NOT NULL AND u.country <> '' " +
+            "AND u.birthdate IS NOT NULL AND u.birthdate <> '' " +
+            "AND u.language IS NOT NULL AND u.language <> '' " +
+
+            // [엔티티 기준 추가 보강] User 엔티티의 updateRoleBasedOnProfile 로직과 일치시킴
+            "AND u.introduction IS NOT NULL AND u.introduction <> '' " +
+            "AND u.hobby IS NOT NULL AND u.hobby <> '' " +
+            "AND u.sex IS NOT NULL AND u.sex <> '' " +
+
+            // (선택) 확실하게 하려면 Role까지 체크
+            "AND u.userRole = 'USER'")
+    List<User> findActiveCandidates(
+            @Param("excludeIds") Collection<Long> excludeIds,
+            @Param("limitTime") Instant limitTime
+    );
     @Query(value = """
             SELECT
               SUM(CASE WHEN last_seen_at IS NOT NULL AND last_seen_at >= NOW() - INTERVAL '24 hour' THEN 1 ELSE 0 END) AS h_0_24,

--- a/src/main/java/core/domain/user/service/ContentBasedRecommender.java
+++ b/src/main/java/core/domain/user/service/ContentBasedRecommender.java
@@ -65,35 +65,46 @@ public class ContentBasedRecommender {
         }
 
         // 4. 내 언어/취미 Set으로 변환 (비교 편의성)
-        Set<String> myLanguages = csvToSet(me.getLanguage());
+        String myCountry = me.getCountry();
         Set<String> myHobbies = csvToSet(me.getHobby());
 
         // 5. 점수 계산 및 정렬, 상위 3명 추출
-        return candidates.stream()
+        List<UserScore> scoredCandidates = candidates.stream()
                 .map(candidate -> {
-                    double score = calculateTotalScore(candidate, myLanguages, myHobbies);
+                    double score = calculateTotalScore(candidate, myCountry, myHobbies);
                     return new UserScore(candidate, score);
                 })
-                .sorted(Comparator.comparingDouble(UserScore::getScore).reversed()) // 점수 높은 순 정렬
-                .limit(limit) // 상위 N명 (여기서는 3명)
+                .sorted(Comparator.comparingDouble(UserScore::getScore).reversed()) // 1. 점수 내림차순 정렬
+                .collect(Collectors.toList());
+
+        // [핵심 변경] 상위 N명을 가져와서 섞음 (Shuffle)
+        // 이유: 활동성 점수가 워낙 강력해서 상위권이 고정되므로, 상위 20명 내에서 랜덤성을 부여
+        int poolSize = Math.min(scoredCandidates.size(), 20); // 상위 20명 (후보가 적으면 전체)
+
+        List<UserScore> topTierPool = new ArrayList<>(scoredCandidates.subList(0, poolSize));
+        Collections.shuffle(topTierPool); // 여기가 마법의 한 줄 (순서를 뒤섞음)
+
+        // 섞인 목록에서 3명 뽑기
+        return topTierPool.stream()
+                .limit(limit)
                 .map(us -> toDto(us.getUser()))
                 .collect(Collectors.toList());
     }
 
     /**
      * [총점 계산 로직]
-     * Total = (활동성 * 50) + (유사도 * 30) + (랜덤 * 20)
+     * Total = (활동성 * 85) + (유사도 * 10) + (랜덤 * 5)
      */
-    private double calculateTotalScore(User candidate, Set<String> myLanguages, Set<String> myHobbies) {
+    private double calculateTotalScore(User candidate, String myCountry, Set<String> myHobbies) {
         double activityScore = calculateActivityScore(candidate);
-        double similarityScore = calculateSimilarityScore(candidate, myLanguages, myHobbies);
-        double randomNoise = Math.random(); // 0.0 ~ 1.0 난수
+        // [변경] 파라미터 변경
+        double similarityScore = calculateSimilarityScore(candidate, myCountry, myHobbies);
+        double randomNoise = Math.random();
 
         return (activityScore * WEIGHT_ACTIVITY)
                 + (similarityScore * WEIGHT_SIMILARITY)
                 + (randomNoise * WEIGHT_RANDOM);
     }
-
     /**
      * [활동성 점수] 0.0 ~ 1.0
      * 최근 접속일수록 1.0에 가까움. 시간이 지날수록 지수적으로 감소.
@@ -113,30 +124,31 @@ public class ContentBasedRecommender {
 
     /**
      * [유사도 점수] 0.0 ~ 1.0
-     * 언어와 취미가 얼마나 겹치는지 계산
+     * 국적(2.0) + 취미(1.0) 가중치 적용
      */
-    private double calculateSimilarityScore(User candidate, Set<String> myLanguages, Set<String> myHobbies) {
-        Set<String> candidateLanguages = csvToSet(candidate.getLanguage());
+    private double calculateSimilarityScore(User candidate, String myCountry, Set<String> myHobbies) {
+        // 1. 국적 점수 계산 (가중치 2.0)
+        // 국적이 같으면 2점, 다르면 0점
+        double countryScore = 0.0;
+        if (myCountry != null && myCountry.equalsIgnoreCase(candidate.getCountry())) {
+            countryScore = 2.0;
+        }
+
+        // 2. 취미 점수 계산 (가중치 1.0)
+        // 일치하는 취미 개수 * 1.0
         Set<String> candidateHobbies = csvToSet(candidate.getHobby());
-
-        // 언어 일치 개수
-        long langMatchCount = candidateLanguages.stream()
-                .filter(myLanguages::contains).count();
-
-        // 취미 일치 개수
         long hobbyMatchCount = candidateHobbies.stream()
                 .filter(myHobbies::contains).count();
+        double hobbyScore = hobbyMatchCount * 1.0;
 
-        // 정규화: (일치 개수 / 전체 개수)로 하면 너무 점수가 작아지므로,
-        // 단순히 일치하는게 하나라도 있으면 점수를 후하게 주는 방식 사용 (Jaccard 유사도 변형)
+        // 3. 정규화 (0.0 ~ 1.0 사이 값으로 변환)
+        // 분모 = 국적 만점(2.0) + 내 취미 개수(다 맞았을 때)
+        double maxPossibleScore = 2.0 + Math.max(1, myHobbies.size());
 
-        double totalMatches = langMatchCount + hobbyMatchCount;
-        double maxPossibleMatches = Math.max(1, myLanguages.size() + myHobbies.size());
+        double totalScore = countryScore + hobbyScore;
 
-        // 최대 1.0을 넘지 않도록
-        return Math.min(1.0, totalMatches / maxPossibleMatches);
+        return Math.min(1.0, totalScore / maxPossibleScore);
     }
-
     // --- Helper Methods ---
 
     private Set<String> csvToSet(String csv) {

--- a/src/main/java/core/domain/user/service/ContentBasedRecommender.java
+++ b/src/main/java/core/domain/user/service/ContentBasedRecommender.java
@@ -9,8 +9,6 @@ import core.global.entity.image.service.ImageService;
 import core.global.enums.FollowStatus;
 import core.global.enums.errorcode.UserErrorCode;
 import core.global.exception.BusinessException;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -29,21 +27,23 @@ public class ContentBasedRecommender {
     private final UserRepository userRepository;
     private final BlockRepository blockRepository;
     private final FollowRepository followRepository;
-
-    private static final double KOREAN_PRIORITY_BOOST = 0.5;
-    private static final double TEMPERATURE = 0.7;
-    private static final double ACTIVITY_SCORE_HALF_LIFE_DAYS = 1.0;
-    private static final java.security.SecureRandom RAND = new java.security.SecureRandom();
     private final ImageService imageService;
 
+    // 가중치 설정 (총합이 중요하기보다 비율이 중요함)
+    // 활동성(최우선) > 유사도(차순위) > 랜덤(매번 다르게)
+    private static final double WEIGHT_ACTIVITY = 70.0;   // 활동 점수 비중 (가장 큼)
+    private static final double WEIGHT_SIMILARITY = 10.0; // 언어/취미 일치 비중
+    private static final double WEIGHT_RANDOM = 20.0;     // 랜덤 노이즈 비중 (순위 섞기용)
 
+    private static final double ACTIVITY_HALF_LIFE_DAYS = 2.0; // 활동 점수가 절반이 되는 기간 (2일 지나면 점수 반토막)
 
     @Transactional(readOnly = true)
     public List<CommendUsersProfileResponse> recommendForUser(Long meId, int limit) {
-
+        // 1. 내 정보 조회
         User me = userRepository.findById(meId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
+        // 2. 제외 대상 필터링 (팔로잉, 차단, 본인)
         List<FollowStatus> statusesToExclude = List.of(FollowStatus.PENDING, FollowStatus.ACCEPTED);
         Set<Long> followingIds = followRepository.findFollowingIdsByUserId(meId, statusesToExclude);
         Set<Long> blockedIds = blockRepository.findAllBlockedUserIds(meId);
@@ -51,89 +51,90 @@ public class ContentBasedRecommender {
         Set<Long> excludeIds = new HashSet<>(followingIds);
         excludeIds.addAll(blockedIds);
         excludeIds.add(meId);
-        if (excludeIds.isEmpty()) {
-            excludeIds.add(0L);
-        }
+        if (excludeIds.isEmpty()) excludeIds.add(0L);
 
-        List<User> allCandidates = userRepository.findFullProfiledRecommendationCandidates(excludeIds);
+        // 3. 후보군 조회 (프로필이 완성된 유저들)
+        // 성능 최적화: 후보가 너무 많다면 DB 레벨에서 최근 접속자 순으로 limit를 걸어 가져오는 것이 좋음
+        List<User> candidates = userRepository.findFullProfiledRecommendationCandidates(excludeIds);
 
-        if (allCandidates.isEmpty()) {
+        if (candidates.isEmpty()) {
             return List.of();
         }
 
-        boolean meIsKorean = isKorean(me.getCountry());
+        // 4. 내 언어/취미 Set으로 변환 (비교 편의성)
+        Set<String> myLanguages = csvToSet(me.getLanguage());
+        Set<String> myHobbies = csvToSet(me.getHobby());
 
-        List<Scored<User>> scoredCandidates;
-
-        if (meIsKorean) {
-            scoredCandidates = allCandidates.stream()
-                    .filter(user -> !isKorean(user.getCountry()))
-                    .map(user -> new Scored<>(
-                            user,
-                            calculateActivityScore(user, ACTIVITY_SCORE_HALF_LIFE_DAYS)
-                    ))
-                    .collect(Collectors.toList());
-
-        } else {
-            scoredCandidates = allCandidates.stream()
-                    .map(user -> {
-                        double activityScore = calculateActivityScore(user, ACTIVITY_SCORE_HALF_LIFE_DAYS);
-                        double boost = isKorean(user.getCountry()) ? KOREAN_PRIORITY_BOOST : 0.0;
-                        return new Scored<>(user, activityScore + boost);
-                    })
-                    .collect(Collectors.toList());
-        }
-
-        if (scoredCandidates.isEmpty()) {
-            return List.of();
-        }
-
-        List<User> chosen = pickGumbelTopK(scoredCandidates, limit, TEMPERATURE);
-        return chosen.stream().map(this::toDto).toList();
+        // 5. 점수 계산 및 정렬, 상위 3명 추출
+        return candidates.stream()
+                .map(candidate -> {
+                    double score = calculateTotalScore(candidate, myLanguages, myHobbies);
+                    return new UserScore(candidate, score);
+                })
+                .sorted(Comparator.comparingDouble(UserScore::getScore).reversed()) // 점수 높은 순 정렬
+                .limit(limit) // 상위 N명 (여기서는 3명)
+                .map(us -> toDto(us.getUser()))
+                .collect(Collectors.toList());
     }
 
     /**
-     * [신규 헬퍼 메서드]
-     * 국가 문자열을 기반으로 한국인 여부를 판단합니다.
-     * TODO: DB에 저장된 실제 '한국' 값으로 변경하세요 (예: "KR", "Republic of Korea" 등)
+     * [총점 계산 로직]
+     * Total = (활동성 * 50) + (유사도 * 30) + (랜덤 * 20)
      */
-    private boolean isKorean(String country) {
-        if (country == null || country.isBlank()) {
-            return false;
-        }
-        String c = country.trim();
-        return "South Korea".equalsIgnoreCase(c) || "Korea".equalsIgnoreCase(c);
+    private double calculateTotalScore(User candidate, Set<String> myLanguages, Set<String> myHobbies) {
+        double activityScore = calculateActivityScore(candidate);
+        double similarityScore = calculateSimilarityScore(candidate, myLanguages, myHobbies);
+        double randomNoise = Math.random(); // 0.0 ~ 1.0 난수
+
+        return (activityScore * WEIGHT_ACTIVITY)
+                + (similarityScore * WEIGHT_SIMILARITY)
+                + (randomNoise * WEIGHT_RANDOM);
     }
 
+    /**
+     * [활동성 점수] 0.0 ~ 1.0
+     * 최근 접속일수록 1.0에 가까움. 시간이 지날수록 지수적으로 감소.
+     */
+    private double calculateActivityScore(User user) {
+        if (user.getLastSeenAt() == null) return 0.0;
 
-    @Getter @AllArgsConstructor
-    private static class Scored<T> { private T item; private double score; }
+        long hoursSinceLastSeen = ChronoUnit.HOURS.between(user.getLastSeenAt(), Instant.now());
+        // 미래 시간인 경우 방어 로직
+        if (hoursSinceLastSeen < 0) hoursSinceLastSeen = 0;
 
-    /** Gumbel-Top-k: key = score/T + Gumbel(0,1) 로 정렬 → 상위 limit 선택(중복 없음) */
-    private List<User> pickGumbelTopK(List<Scored<User>> pool, int limit, double temperature) {
-        class Draw { final User u; final double key; Draw(User u, double key){this.u=u; this.key=key;} }
-        List<Draw> draws = new ArrayList<>(pool.size());
-        double T = Math.max(1e-6, temperature);
-        for (Scored<User> s : pool) {
-            double u = RAND.nextDouble();
-            double gumbel = -Math.log(-Math.log(u));
-            double key = (s.score / T) + gumbel;
-            draws.add(new Draw(s.item, key));
-        }
-        draws.sort((a, b) -> Double.compare(b.key, a.key));
-        return draws.stream().limit(Math.max(1, limit)).map(d -> d.u).toList();
+        double daysSince = hoursSinceLastSeen / 24.0;
+        double decayRate = Math.log(2) / ACTIVITY_HALF_LIFE_DAYS;
+
+        return Math.exp(-decayRate * daysSince);
     }
 
-    /** 사용자의 마지막 활동 시간(lastSeenAt)을 바탕으로 0.0 ~ 1.0 사이의 활동 점수를 계산 */
-    private double calculateActivityScore(User user, double halfLifeDays) {
-        if (user.getLastSeenAt() == null) {
-            return 0.0;
-        }
-        long hoursSinceUpdate = ChronoUnit.HOURS.between(user.getLastSeenAt(), Instant.now());
-        double daysSinceUpdate = hoursSinceUpdate / 24.0;
-        double decayRate = Math.log(2) / halfLifeDays;
-        return Math.exp(-decayRate * daysSinceUpdate);
+    /**
+     * [유사도 점수] 0.0 ~ 1.0
+     * 언어와 취미가 얼마나 겹치는지 계산
+     */
+    private double calculateSimilarityScore(User candidate, Set<String> myLanguages, Set<String> myHobbies) {
+        Set<String> candidateLanguages = csvToSet(candidate.getLanguage());
+        Set<String> candidateHobbies = csvToSet(candidate.getHobby());
+
+        // 언어 일치 개수
+        long langMatchCount = candidateLanguages.stream()
+                .filter(myLanguages::contains).count();
+
+        // 취미 일치 개수
+        long hobbyMatchCount = candidateHobbies.stream()
+                .filter(myHobbies::contains).count();
+
+        // 정규화: (일치 개수 / 전체 개수)로 하면 너무 점수가 작아지므로,
+        // 단순히 일치하는게 하나라도 있으면 점수를 후하게 주는 방식 사용 (Jaccard 유사도 변형)
+
+        double totalMatches = langMatchCount + hobbyMatchCount;
+        double maxPossibleMatches = Math.max(1, myLanguages.size() + myHobbies.size());
+
+        // 최대 1.0을 넘지 않도록
+        return Math.min(1.0, totalMatches / maxPossibleMatches);
     }
+
+    // --- Helper Methods ---
 
     private Set<String> csvToSet(String csv) {
         if (csv == null || csv.isBlank()) return Set.of();
@@ -145,7 +146,19 @@ public class ContentBasedRecommender {
 
     private CommendUsersProfileResponse toDto(User u) {
         String imageKey = imageService.getUserProfileKey(u.getId());
+        return new CommendUsersProfileResponse(
+                u,
+                csvToSet(u.getLanguage()).stream().toList(),
+                csvToSet(u.getHobby()).stream().toList(),
+                imageKey
+        );
+    }
 
-        return new CommendUsersProfileResponse(u,  csvToSet(u.getLanguage()).stream().toList(), csvToSet(u.getHobby()).stream().toList(),imageKey);
+    // 내부 점수 래퍼 클래스
+    @lombok.AllArgsConstructor
+    @lombok.Getter
+    private static class UserScore {
+        private User user;
+        private double score;
     }
 }

--- a/src/main/java/core/domain/user/service/ContentBasedRecommender.java
+++ b/src/main/java/core/domain/user/service/ContentBasedRecommender.java
@@ -29,13 +29,13 @@ public class ContentBasedRecommender {
     private final FollowRepository followRepository;
     private final ImageService imageService;
 
-    // 가중치 설정 (총합이 중요하기보다 비율이 중요함)
-    // 활동성(최우선) > 유사도(차순위) > 랜덤(매번 다르게)
-    private static final double WEIGHT_ACTIVITY = 70.0;   // 활동 점수 비중 (가장 큼)
-    private static final double WEIGHT_SIMILARITY = 10.0; // 언어/취미 일치 비중
-    private static final double WEIGHT_RANDOM = 20.0;     // 랜덤 노이즈 비중 (순위 섞기용)
-
-    private static final double ACTIVITY_HALF_LIFE_DAYS = 2.0; // 활동 점수가 절반이 되는 기간 (2일 지나면 점수 반토막)
+    private static final double WEIGHT_ACTIVITY = 85.0;
+    // 최소한의 취향 (말은 통해야 하니까)
+    private static final double WEIGHT_SIMILARITY = 10.0;
+    // 랜덤 비중을 5로 축소 (활동적인 사람이 랜덤 운 때문에 밀려나지 않도록)
+    private static final double WEIGHT_RANDOM = 5.0;
+    // [핵심] 반감기를 '1일'에서 '0.25일(6시간)' 또는 '0.1일(2.4시간)'으로 단축
+    private static final double ACTIVITY_HALF_LIFE_DAYS = 0.1;
 
     @Transactional(readOnly = true)
     public List<CommendUsersProfileResponse> recommendForUser(Long meId, int limit) {
@@ -53,10 +53,13 @@ public class ContentBasedRecommender {
         excludeIds.add(meId);
         if (excludeIds.isEmpty()) excludeIds.add(0L);
 
-        // 3. 후보군 조회 (프로필이 완성된 유저들)
-        // 성능 최적화: 후보가 너무 많다면 DB 레벨에서 최근 접속자 순으로 limit를 걸어 가져오는 것이 좋음
-        List<User> candidates = userRepository.findFullProfiledRecommendationCandidates(excludeIds);
+        Instant activeLimit = Instant.now().minus(3, ChronoUnit.DAYS);
 
+        List<User> candidates = userRepository.findActiveCandidates(excludeIds, activeLimit);
+        if (candidates.isEmpty()) {
+            activeLimit = Instant.now().minus(14, ChronoUnit.DAYS);
+            candidates = userRepository.findActiveCandidates(excludeIds, activeLimit);
+        }
         if (candidates.isEmpty()) {
             return List.of();
         }

--- a/src/main/java/core/domain/user/service/ContentBasedRecommender.java
+++ b/src/main/java/core/domain/user/service/ContentBasedRecommender.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.security.SecureRandom;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
@@ -28,9 +29,8 @@ public class ContentBasedRecommender {
     private final BlockRepository blockRepository;
     private final FollowRepository followRepository;
     private final ImageService imageService;
-
+    private final SecureRandom secureRandom = new SecureRandom();
     private static final double WEIGHT_ACTIVITY = 85.0;
-    // 최소한의 취향 (말은 통해야 하니까)
     private static final double WEIGHT_SIMILARITY = 10.0;
     // 랜덤 비중을 5로 축소 (활동적인 사람이 랜덤 운 때문에 밀려나지 않도록)
     private static final double WEIGHT_RANDOM = 5.0;
@@ -99,7 +99,7 @@ public class ContentBasedRecommender {
         double activityScore = calculateActivityScore(candidate);
         // [변경] 파라미터 변경
         double similarityScore = calculateSimilarityScore(candidate, myCountry, myHobbies);
-        double randomNoise = Math.random();
+        double randomNoise = secureRandom.nextDouble();
 
         return (activityScore * WEIGHT_ACTIVITY)
                 + (similarityScore * WEIGHT_SIMILARITY)


### PR DESCRIPTION
# 📄 PR 변경사항

* **추천 시스템 로직 전면 개편 (활동성 강화 + 국적 매칭 도입)**
* 추천 품질 개선을 위해 점수 산정 방식과 후보군 필터링 로직을 변경했습니다.
* '새로고침' 시 매번 같은 유저가 뜨는 문제를 해결하기 위해 Top-Tier 셔플 로직을 추가했습니다.



# 🖌️ 구체적인 구현 내용

**1. 점수 가중치 및 반감기 최적화**

* **가중치 변경:** `Activity(85%)`, `Similarity(10%)`, `Random(5%)`
* **반감기 단축:** `1일` → **`2.4시간(0.1일)`** 로 대폭 축소하여 "지금 접속 중인 유저"가 압도적으로 높은 점수를 받도록 조정했습니다.

**2. 유사도(Similarity) 로직 변경**

* 기존: 언어(Language) + 취미(Hobby) 단순 합산
* **변경:** **국적(Country) + 취미(Hobby)**
* **국적(가중치 2.0):** 말이 통하고 문화권이 같은 유저를 우선 추천 (대소문자 무관 비교)
* **취미(가중치 1.0):** 부가적인 관심사 매칭



**3. Top-Tier 셔플(Shuffle) 도입**

* 활동성 점수의 변별력이 높아 상위권 유저가 고정되는 현상을 방지했습니다.
* **로직:** 점수 상위 20명을 뽑은 뒤, 그 안에서 무작위로 섞어 최종 `limit`만큼 반환합니다.

**4. 유령 회원 필터링**

* DB 조회 단계에서 최근 3일 이내 접속자만 1차적으로 필터링하여 쿼리 효율과 추천 품질을 동시에 높였습니다.

# ✨개선 사항 및 참고 사항

* `User` 엔티티의 `getCountry()`를 사용하여 국적 일치 여부를 판단합니다.
* `ContentBasedRecommender` 내 주석을 현재 로직(85/10/5)에 맞게 최신화했습니다.

# 💯 테스트


# 확인

* [x] 주석 및 print를 제거하셨나요?
* [x] javaDoc을 작성하셨나요?
* [x] merge할 브랜치와 로컬에서 merge 하셨나요?
* [x] 더 수정할 작업은 없는지 확인하셨나요?

---