### PR TITLE
채팅방 유저 방 유저 입장,어드민추방,db 고아 데이터 관련 수정 

### DIFF
--- a/src/main/java/core/domain/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/core/domain/chat/repository/ChatParticipantRepository.java
@@ -57,4 +57,8 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
 
     @Query("SELECT u.firstName FROM ChatParticipant cp JOIN cp.user u WHERE cp.chatRoom.id = :roomId")
     List<String> findParticipantNamesByRoomId(@Param("roomId") Long roomId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM ChatParticipant cp WHERE cp.chatRoom.id = :roomId")
+    void deleteByChatRoomId(@Param("roomId") Long roomId);
 }

--- a/src/main/java/core/domain/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/core/domain/chat/repository/ChatParticipantRepository.java
@@ -23,7 +23,7 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
     Optional<ChatParticipant> findByChatRoomIdAndUserIdAndStatusIsNot(Long chatRoomId, Long userId, ChatParticipantStatus status);
 
     @Query("SELECT cp FROM ChatParticipant cp WHERE cp.chatRoom.id = :roomId AND cp.user.id = :userId")
-    Optional<ChatParticipant> findByChatRoomIdAndUserId(@Param("roomId") Long roomId, @Param("userId") Long userId)
+    Optional<ChatParticipant> findByChatRoomIdAndUserId(@Param("roomId") Long roomId, @Param("userId") Long userId);
 
 
 

--- a/src/main/java/core/domain/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/core/domain/chat/repository/ChatParticipantRepository.java
@@ -22,8 +22,8 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
 
     Optional<ChatParticipant> findByChatRoomIdAndUserIdAndStatusIsNot(Long chatRoomId, Long userId, ChatParticipantStatus status);
 
-    Optional<ChatParticipant> findByChatRoomIdAndUserId(Long chatRoomId, Long userId);
-
+    @Query("SELECT cp FROM ChatParticipant cp WHERE cp.chatRoom.id = :roomId AND cp.user.id = :userId")
+    Optional<ChatParticipant> findByChatRoomIdAndUserId(@Param("roomId") Long roomId, @Param("userId") Long userId)
 
 
 

--- a/src/main/java/core/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/core/domain/chat/service/ChatMessageService.java
@@ -26,6 +26,7 @@ import core.global.exception.BusinessException;
 import core.global.metrics.ChatMetrics;
 import core.global.service.PerspectiveService;
 import core.global.service.TranslationService;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -729,85 +730,100 @@ public class ChatMessageService {
                     .collect(Collectors.toList());
         }
     }
-
-    @Transactional
+    @Transactional(readOnly = true)
     public List<ChatMessageResponse> getMessagesAround(Long roomId, Long userId, Long targetMessageId) {
-        // 1. 참여자 조회 (권한 체크)
+        // 1. 참여자 검증
         ChatParticipant participant = chatParticipantRepository.findByChatRoomIdAndUserId(roomId, userId)
                 .orElseThrow(() -> new BusinessException(ChatErrorCode.NOT_CHAT_PARTICIPANT));
 
         // 2. 메시지 조회 (Cursor Paging)
-        // 2-1. 과거 메시지
         List<ChatMessage> older = chatMessageRepository.findTop20ByChatRoomIdAndIdLessThanOrderByIdDesc(roomId, targetMessageId);
         Collections.reverse(older);
 
-        // 2-2. 타겟 메시지
         ChatMessage target = chatMessageRepository.findById(targetMessageId)
                 .orElseThrow(() -> new BusinessException(ChatErrorCode.MESSAGE_NOT_FOUND));
 
-        // 2-3. 미래 메시지
         List<ChatMessage> newer = chatMessageRepository.findTop20ByChatRoomIdAndIdGreaterThanOrderByIdAsc(roomId, targetMessageId);
 
-        // 2-4. 리스트 합치기
         List<ChatMessage> combined = new ArrayList<>();
         combined.addAll(older);
         combined.add(target);
         combined.addAll(newer);
 
-        // 3. [N+1 방지] 보낸 사람 정보 일괄 조회 (Loop 사용)
+        // 3. [안전 장치] 데이터 추출 (삭제된 유저 방어 로직)
         Set<Long> senderIds = new HashSet<>();
         for (ChatMessage msg : combined) {
-            // [수정] getSenderId() -> getSender().getId() 로 변경
-            if (msg.getSender() != null) {
-                senderIds.add(msg.getSender().getId());
+            try {
+                // 🚨 핵심: 여기서 삭제된 유저의 프록시를 건드리면 EntityNotFound 발생
+                // 예외를 잡아서 서버가 죽지 않게 방어함
+                User sender = msg.getSender();
+                if (sender != null) {
+                    senderIds.add(sender.getId()); // ID 접근 시 실제 DB 확인
+                }
+            } catch (EntityNotFoundException e) {
+                // 삭제된 유저(고아 데이터)입니다. 로그만 남기고 무시합니다.
+                // senderIds에 추가되지 않으므로 아래 로직에서 'Unknown' 처리됩니다.
             }
         }
 
-        List<User> users = userRepository.findAllById(senderIds);
+        // 4. [성능 최적화] 유저 및 프로필 이미지 일괄 조회 (N+1 방지)
         Map<Long, User> senderMap = new HashMap<>();
-        for (User user : users) {
-            senderMap.put(user.getId(), user);
+        Map<Long, String> profileImageMap = new HashMap<>();
+
+        if (!senderIds.isEmpty()) {
+            // 유저 조회
+            List<User> users = userRepository.findAllById(senderIds);
+            for (User u : users) {
+                senderMap.put(u.getId(), u);
+            }
+
+            // 프로필 이미지 조회 (Bulk)
+            List<Image> images = imageRepository.findAllByImageTypeAndRelatedIdInOrderByOrderIndexAsc(ImageType.USER, new ArrayList<>(senderIds));
+            for (Image img : images) {
+                profileImageMap.putIfAbsent(img.getRelatedId(), img.getUrl());
+            }
         }
 
-        // 4. 번역 처리
+        // 5. 번역 처리
         Map<Long, String> translatedMap = Collections.emptyMap();
         if (participant.isTranslateEnabled() && participant.getUser().getTranslateLanguage() != null) {
             translatedMap = chatTranslationService.getTranslatedMessages(combined, participant.getUser().getTranslateLanguage());
         }
 
-        // 5. 응답 변환 (Loop 사용)
+        // 6. 응답 변환
         List<ChatMessageResponse> responseList = new ArrayList<>();
-
         for (ChatMessage msg : combined) {
-            // 5-1. 사용자 정보 가져오기 ([수정] getSender().getId() 사용)
-            Long currentSenderId = (msg.getSender() != null) ? msg.getSender().getId() : null;
-            User sender = senderMap.get(currentSenderId);
+            Long senderId = null;
+            try {
+                // 여기서도 getSender() 호출 시 에러 날 수 있으므로 방어
+                if (msg.getSender() != null) {
+                    senderId = msg.getSender().getId();
+                }
+            } catch (EntityNotFoundException e) {
+            }
 
-            // 5-2. 번역 정보 가져오기
+            User sender = (senderId != null) ? senderMap.get(senderId) : null;
+            String profileUrl = (senderId != null) ? profileImageMap.get(senderId) : null;
             String translated = translatedMap.get(msg.getId());
 
-            // 5-3. DTO 변환 및 리스트 추가
-            ChatMessageResponse response = mapToResponse(msg, sender, translated);
-            responseList.add(response);
+            responseList.add(mapToResponse(msg, sender, profileUrl, translated));
         }
 
         return responseList;
     }
 
     /**
-     * [Helper] Entity -> Record DTO 변환
+     * [Helper] 안전한 DTO 변환기
+     * - 이제 이 안에서는 DB 조회를 하지 않습니다.
      */
-    private ChatMessageResponse mapToResponse(ChatMessage msg, User sender, String translatedContent) {
+    private ChatMessageResponse mapToResponse(ChatMessage msg, User sender, String profileImageUrl, String translatedContent) {
         String content = msg.getContent();
         String mediaUrl = null;
         String thumbnailUrl = null;
 
-        // --- 미디어(이미지/비디오) 처리 로직 ---
+        // --- 미디어 처리 ---
         if (msg.getMessageType() == MessageType.IMAGE || msg.getMessageType() == MessageType.VIDEO) {
-            // 1. 원본 URL 생성
             mediaUrl = s3ImageStorageClient.generatePublicUrl(msg.getContent());
-
-            // 2. 비디오라면 썸네일 URL 생성
             if (msg.getMessageType() == MessageType.VIDEO) {
                 thumbnailUrl = s3ImageStorageClient.generateThumbnailUrl(msg.getContent());
                 content = "video";
@@ -816,41 +832,36 @@ public class ChatMessageService {
             }
         }
 
-        // --- 보낸 사람 정보 처리 (Null Safety) ---
-        String senderFirstName = "Unknown";
+        // --- 보낸 사람 정보 (기본값 설정) ---
+        String senderFirstName = "Unknown"; // 기본값: 알 수 없음
         String senderLastName = "";
-        String senderImageUrl = null;
 
         if (sender != null) {
             senderFirstName = sender.getFirstName();
             senderLastName = sender.getLastName();
-            senderImageUrl = imageRepository.findFirstByImageTypeAndRelatedIdOrderByOrderIndexAsc(ImageType.USER, sender.getId())
-                    .map(Image::getUrl).orElse(null);
-
         }
 
-        // --- ID 추출 수정 ---
-        // msg.getSenderId() -> msg.getSender().getId()
-        Long msgSenderId = (msg.getSender() != null) ? msg.getSender().getId() : null;
+        // --- ID 안전 추출 ---
+        Long msgSenderId = null;
+        Long msgRoomId = msg.getChatRoom().getId();
 
-        // msg.getChatRoomId() -> msg.getChatRoom().getId()
-        // (만약 엔티티에 getChatRoom()만 있다면 아래처럼 호출해야 함)
-        Long msgRoomId = (msg.getChatRoom() != null) ? msg.getChatRoom().getId() : null;
+        try {
+            if (sender != null) msgSenderId = sender.getId();
+        } catch (Exception e) { /* 무시 */ }
 
-        // --- Record 생성 및 반환 ---
         return new ChatMessageResponse(
                 msg.getId(),
                 msgRoomId,
                 msgSenderId,
-                content,            // originContent
-                translatedContent,  // targetContent
-                msg.getSentAt(),    // sentAt (Instant)
+                content,
+                translatedContent,
+                msg.getSentAt(),
                 senderFirstName,
                 senderLastName,
-                senderImageUrl,
-                msg.getMessageType(), // messageType
-                mediaUrl,           // mediaUrl
-                thumbnailUrl        // thumbnailUrl
+                profileImageUrl, // 미리 조회한 URL 사용
+                msg.getMessageType(),
+                mediaUrl,
+                thumbnailUrl
         );
     }
 

--- a/src/main/java/core/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/core/domain/chat/service/ChatRoomService.java
@@ -174,7 +174,6 @@ public class ChatRoomService {
                         },
                         () -> {
                             ChatParticipant newParticipant = new ChatParticipant(room, user);
-                            room.addParticipant(newParticipant);
                             chatParticipantRepository.save(newParticipant);
                         }
                 );

--- a/src/main/java/core/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/core/domain/chat/service/ChatRoomService.java
@@ -21,6 +21,7 @@ import core.global.enums.errorcode.ChatErrorCode;
 import core.global.enums.errorcode.UserErrorCode;
 import core.global.exception.BusinessException;
 import core.global.metrics.SocialChatMetrics;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -181,47 +182,24 @@ public class ChatRoomService {
 
     @Transactional
     public boolean leaveRoom(Long roomId, Long userId) {
-        long startTime = System.currentTimeMillis();
-        log.info("🚪 [Leave 요청] 나가기 프로세스 시작 | RoomId: {}, UserId: {}", roomId, userId);
 
-        try {
-            User user = userRepository.findById(userId)
-                    .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
-
-            userRoleDetectService.isProfileSetUpUser(user);
-
-            ChatParticipant participant = chatParticipantRepository.findByChatRoomIdAndUserIdAndStatusIsNot(roomId, userId, ChatParticipantStatus.LEFT)
-                    .orElseThrow(() -> new BusinessException(ChatErrorCode.CHAT_PARTICIPANT_NOT_FOUND));
-
-            participant.leave();
-
-            chatParticipantRepository.flush();
-
-            deleteRoomIfEmpty(roomId);
-
+        ChatParticipant participant = chatParticipantRepository.findByChatRoomIdAndUserId(roomId, userId)
+                .orElseThrow(() -> new BusinessException(ChatErrorCode.CHAT_PARTICIPANT_NOT_FOUND));
+        if (participant.getStatus() == ChatParticipantStatus.LEFT) {
             return true;
-
-        } catch (PessimisticLockingFailureException | QueryTimeoutException e) {
-            // 🚨 DB 락 획득 실패 (데드락 또는 타임아웃)
-            long duration = System.currentTimeMillis() - startTime;
-            log.error("💥 [Lock 실패] DB 락 획득 실패 (채팅량 과다 의심) | 소요시간: {}ms | RoomId: {}, UserId: {}", duration, roomId, userId);
-            throw e; // 예외는 다시 던져서 컨트롤러가 알게 함
-
-        } catch (Exception e) {
-            // 기타 에러
-            log.error("❌ [Leave 에러] 나가기 처리 중 오류 발생 | RoomId: {}, UserId: {}", roomId, userId, e);
-            throw e;
-
-        } finally {
-            // 5. 소요 시간 측정 및 Slow Query 경고
-            long duration = System.currentTimeMillis() - startTime;
-
-            if (duration > 1000) { // 1초 이상 걸리면 경고 (임계값 조절 가능)
-                log.warn("⏳ [Slow Logic] 나가기 처리가 지연됨 (Lock 경합 유력) | 소요시간: {}ms | RoomId: {}, UserId: {}", duration, roomId, userId);
-            } else {
-                log.info("✅ [Leave 완료] 정상 처리 | 소요시간: {}ms", duration);
-            }
         }
+        try {
+            participant.leave();
+        } catch (EntityNotFoundException e) {
+            log.warn("⚠️ 존재하지 않는 유저의 나가기 요청 (Data Integrity Issue) - RoomId: {}, UserId: {}", roomId, userId);
+            chatParticipantRepository.delete(participant);
+            return true;
+        }
+
+        // 4. 방이 비었는지 확인 후 삭제
+        deleteRoomIfEmpty(roomId);
+
+        return true;
     }
     @Transactional(readOnly = true)
     public boolean isChatRoomGroup(Long roomId) {

--- a/src/main/java/core/domain/user/service/UserAdminService.java
+++ b/src/main/java/core/domain/user/service/UserAdminService.java
@@ -167,41 +167,55 @@ public class UserAdminService {
      */
     @Transactional
     public void hardDeleteUser(Long userId) {
-        Optional<User> user =userRepository.findById(userId);
-        User NowUser = new User();
-        if(user.isPresent()) {
-            NowUser = user.get();
-        }
-        List<ChatRoom> ownedChatRooms = chatRoomRepository.findAllByOwnerId(userId);
+        // 1. 유저 조회 (없으면 바로 종료 or 예외 처리)
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
+        // 2. 채팅방 방장 위임 처리
+        List<ChatRoom> ownedChatRooms = chatRoomRepository.findAllByOwnerId(userId);
         for (ChatRoom chatRoom : ownedChatRooms) {
+            // 방장 제외 다른 참여자 조회
             List<ChatParticipant> participants = chatParticipantRepository.findAllByChatRoomIdAndUserIdNot(chatRoom.getId(), userId);
 
             if (!participants.isEmpty()) {
                 User newOwner = participants.get(0).getUser();
                 chatRoom.changeOwner(newOwner);
-                chatRoomRepository.save(chatRoom);
             } else {
+                // 참여자가 없으면 방 폭파 (연관된 메시지, 참여자 정보도 같이 삭제되어야 함)
+                // Cascade 설정이 안 되어 있다면 아래처럼 수동 삭제 필요
+                chatMessageRepository.deleteByChatRoomId(chatRoom.getId());
+                chatParticipantRepository.deleteByChatRoomId(chatRoom.getId());
                 chatRoomRepository.delete(chatRoom);
             }
         }
-        blockPostRepository.deleteAllBlockPostsRelatedToUser(userId);
+
+        // 3. 연관 데이터 삭제 (순서 중요: 자식 -> 부모)
+
+        // 게시글 관련
         List<Post> userPosts = postRepository.findAllByAuthorId(userId);
-        if (userPosts != null && !userPosts.isEmpty()) {
+        if (!userPosts.isEmpty()) {
             commentRepository.deleteAllByPostIn(userPosts);
             bookmarkRepository.deleteAllByPostIn(userPosts);
             postRepository.deleteAll(userPosts);
         }
 
+        // 나머지 단순 삭제들 (반드시 Repository에 @Modifying @Query 적용 권장)
+        blockPostRepository.deleteAllBlockPostsRelatedToUser(userId);
         commentRepository.deleteAllByAuthorId(userId);
         bookmarkRepository.deleteAllByUserId(userId);
         followRepository.deleteAllByUserId(userId);
         likeRepository.deleteAllByUserId(userId);
+
+        // [중요] 메시지를 먼저 지우고 참여 정보를 지우는 것이 FK 관점에서 안전
+        chatMessageRepository.deleteAllBySenderId(userId);
+        chatParticipantRepository.deleteAllByUserId(userId);
+
         imageRepository.deleteAllByImageTypeAndRelatedId(ImageType.USER, userId);
         imageService.deleteUserProfileImage(userId);
-        blockRepository.deleteAllByUserOrBlocked(NowUser);
-        chatParticipantRepository.deleteAllByUserId(userId);
-        chatMessageRepository.deleteAllBySenderId(userId);
+
+        // 차단 목록은 User 객체가 필요하므로 여기서 처리
+        blockRepository.deleteAllByUserOrBlocked(user);
+
         userNotificationSettingRepository.deleteAllByUserId(userId);
         userDeviceTokenRepository.deleteAllByUserId(userId);
         notificationRepository.deleteAllByUserId(userId);
@@ -209,7 +223,9 @@ public class UserAdminService {
         userFeedbackRepository.deleteAllByUserIdExplicit(userId);
         aiPersonaRepository.deleteByUserId(userId);
 
-        userRepository.delete(NowUser);
+        // 4. 마지막으로 유저 삭제
+        userRepository.delete(user);
+
         log.info(">>>> Deleted user entity for userId: {}", userId);
     }
 


### PR DESCRIPTION
# 📄 PR 변경사항
채팅방 재입장 불가 버그(Duplicate Key Error) 수정 (#506)
회원 탈퇴 시 채팅 관련 데이터 정합성 문제 및 조회 에러 해결 (#504)
게시글 작성 시 발생하던 DB 인덱스 손상 오류 복구 및 정상화 (#505)

---

# 🖌️ 구체적인 구현 내용

**1. 채팅방 재입장 로직 수정 (Issue #506)**

* **원인:** `ChatParticipantRepository`의 조회 메서드가 이미 방을 나간(`LEFT`) 유저를 찾지 못해, 재입장 시 `UPDATE`가 아닌 `INSERT`를 시도하여 `uk_chatroom_user` 제약 조건 위반이 발생함.
* **해결:**
* Repository에 `@Query`를 적용하여 `status`와 무관하게 참여자 정보를 조회하도록 변경.
* 기존 참여 이력이 존재할 경우 `reJoin()`을 호출하여 상태를 `ACTIVE`로 복구하도록 로직 개선.
* `room.addParticipant()` 등 불필요한 연관관계 편의 메서드 호출을 제거하여 영속성 컨텍스트 충돌 방지.



**2. 회원 탈퇴 시 데이터 삭제 순서 및 로직 강화 (Issue #504)**

* **원인:** 회원 탈퇴(`hardDeleteUser`) 시 `User`만 삭제되고 연관된 `ChatMessage`나 `ChatParticipant`가 남아있어, 채팅방 목록 조회(`getMyChatRooms`) 시 존재하지 않는 유저를 참조하다 `EntityNotFoundException`이 발생함.
* **해결:**
* 탈퇴 프로세스에 **[ 메시지 삭제 -> 참여 정보 삭제 -> 유저 삭제 ]** 순서를 적용하여 참조 무결성 보장.
* db의 고아 데이터들 수동으로 정리 



**3. 게시글 작성 실패 및 DB 인덱스 손상 복구 (Issue #505)**

* **원인:** 게시글 작성(`INSERT`) 시도시 PostgreSQL 내부 오류(`heap tid from index tuple ... points to heap-only tuple`)가 발생. 확인 결과 `idx_post_board_created_id` 인덱스 파일이 물리적으로 손상됨.
* **해결:**
* 애플리케이션 로직 오류가 아닌 DB 스토리지 이슈임을 확인.
* 해당 테이블 및 인덱스에 대해 `REINDEX` 작업을 수행하여 손상된 인덱스를 재구축 및 정상화 완료.

# ✨개선 사항 및 참고 사항



# 💯 테스트



# 확인

* [ ] 주석 및 print를 제거하셨나요?
* [ ] javaDoc을 작성하셨나요?
* [ ] merge할 브랜치와 로컬에서 merge 하셨나요?
* [ ] 더 수정할 작업은 없는지 확인하셨나요?