### PR TITLE
Bugfix/510 게시글 목록 조회 시 이미지 서브쿼리 다중 결과 에러 해결 limit1 적용

### DIFF
--- a/src/main/java/core/domain/post/repository/impl/PostRepositoryImpl.java
+++ b/src/main/java/core/domain/post/repository/impl/PostRepositoryImpl.java
@@ -260,6 +260,8 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                                         userImage.imageType.eq(IMAGE_TYPE_USER)
                                                 .and(userImage.relatedId.eq(user.id))
                                 )
+                                .orderBy(userImage.id.desc())
+                                .limit(1)
                 );
 
         QImage image = QImage.image;
@@ -610,29 +612,23 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 .where(
                         u.imageType.eq(IMAGE_TYPE_USER)
                                 .and(u.relatedId.eq(user.id))
-                );
+                )
+                .orderBy(u.id.desc())
+                .limit(1);
     }
 
     private Expression<String> firstPostImageUrlExpr() {
-        QImage pi1 = new QImage("pi1");
-        QImage pi2 = new QImage("pi2");
+        QImage pi = new QImage("pi");
 
         return JPAExpressions
-                .select(pi2.url)
-                .from(pi2)
+                .select(pi.url)
+                .from(pi)
                 .where(
-                        pi2.imageType.eq(IMAGE_TYPE_POST),
-                        pi2.relatedId.eq(post.id),
-                        pi2.id.eq(
-                                JPAExpressions
-                                        .select(pi1.id.min())
-                                        .from(pi1)
-                                        .where(
-                                                pi1.imageType.eq(IMAGE_TYPE_POST),
-                                                pi1.relatedId.eq(post.id)
-                                        )
-                        )
-                );
+                        pi.imageType.eq(IMAGE_TYPE_POST),
+                        pi.relatedId.eq(post.id)
+                )
+                .orderBy(pi.orderIndex.asc(), pi.id.asc())
+                .limit(1); // 첫 번째 이미지 1장만
     }
 
     private Expression<Long> commentCountExpr() {

--- a/src/main/java/core/global/entity/like/entity/Like.java
+++ b/src/main/java/core/global/entity/like/entity/Like.java
@@ -17,7 +17,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class Like {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "likes_id")
     private Long id;
 
@@ -25,6 +26,7 @@ public class Like {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "type", nullable = false)
     private LikeType type;
 

--- a/src/main/resources/db/migration/V202512261730__change_image_not_duplicate.sql
+++ b/src/main/resources/db/migration/V202512261730__change_image_not_duplicate.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public.image ADD CONSTRAINT uq_image_type_related_id_order UNIQUE (image_type, related_id, order_index);
+
+ALTER TABLE public.likes ADD CONSTRAINT uq_likes_user_type_related UNIQUE (user_id, type, related_id);


### PR DESCRIPTION
# 📄 PR 변경사항
- image, like 중복 related_id 로 인해 문제가 발생할 수 있는 부분 방지

# 🖌️ 구체적인 구현 내용
<!--  어떤 점을 고려하여 구현하였는지, 어떤 예외를 던지는지 등의 내용을 알려주세요! -->
- Like 엔티티 EnumRated(String) 적용\
- like, Image db 유니크 제약 조건 추가
- postRepository limit(1)으로 오류 방지

# ✨개선 사항 및 참고 사항
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 


# 💯 테스트
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 

# 확인
- [ ] 주석 및 print를 제거하셨나요?
- [ ] javaDoc을 작성하셨나요?
- [ ] merge할 브랜치와 로컬에서 merge 하셨나요?
- [ ] 더 수정할 작업은 없는지 확인하셨나요?
