### PR TITLE
AI 대화/온보딩 로직 고도화 및 스팸 방지, 버그 수정

### DIFF
--- a/src/main/java/core/domain/ai/service/AiChatUserService.java
+++ b/src/main/java/core/domain/ai/service/AiChatUserService.java
@@ -148,20 +148,130 @@ public class AiChatUserService {
     // --- Helper Methods (DB 접근 없음) ---
 
     private boolean shouldReply(String message, User aiUser, boolean isGroupChat, long activeHumanCount) {
-        if (isMentioned(message, aiUser.getFirstName())) {
+        // 1. 이름이 불리면 무조건 대답 (100%)
+        if (isMentioned(message, aiUser.getFirstName(), aiUser.getLastName())) {
             return true;
         }
+
+        // 2. 1:1 채팅이거나, 그룹방인데 말하는 사람이 1명뿐이면 (사실상 1:1) 무조건 대답
         if (!isGroupChat || activeHumanCount <= 1) {
             return true;
         }
-        if (message.contains("?") || message.endsWith("?")) {
-            return secureRandom.nextInt(100) < 30;
+
+        // 3. [NEW] 내 취미(Hobby) 관련 키워드가 나오면 높은 확률로 끼어듦 (85%)
+        // 예: 취미가 "영화"인데 "영화 볼래?" 하면 거의 무조건 반응
+        String hobby = aiUser.getHobby();
+        if (hobby != null && !hobby.isBlank() && message.contains(hobby)) {
+            log.info("AI [{}] Interest Triggered! Keyword: {}", aiUser.getFirstName(), hobby);
+            return secureRandom.nextInt(100) < 85;
         }
-        return secureRandom.nextInt(100) < 5;
+
+        // 4. 질문형 메시지일 때 확률 대폭 상향 (30% -> 60%)
+        // 그룹챗이어도 질문에는 절반 이상 반응해줘야 '티키타카'가 됨
+        if (message.contains("?") || message.endsWith("?")) {
+            return secureRandom.nextInt(100) < 60;
+        }
+
+        // 5. 일반 평서문일 때 확률 상향 (5% -> 15%)
+        // 너무 높으면 AI끼리만 떠들 수 있으니 적당히 올림
+        return secureRandom.nextInt(100) < 15;
+    }
+    /**
+     * 🕵️‍♂️ 강력한 멘션 감지 메서드
+     * 1. 성(Last), 이름(First), 전체 이름(Full) 모두 체크
+     * 2. 대소문자 구분 없음 (Doehyn == doehyn)
+     * 3. 오타 허용 (Levenshtein Distance: 도혅 -> 도현 인식)
+     * 4. 한국어/영어 혼용 대응을 위해 닉네임 필드 활용 권장
+     */
+    /**
+     * 🕵️‍♂️ 강력한 멘션 감지 메서드 (닉네임 제외)
+     * 1. 성(Last), 이름(First), 전체 이름(Full) 조합 체크
+     * 2. 대소문자 구분 없음
+     * 3. 오타 허용 (Fuzzy Match)
+     */
+    private boolean isMentioned(String message, String firstName, String lastName) {
+        if (message == null || message.isBlank()) return false;
+
+        // 1. 비교할 이름 후보군 생성
+        List<String> nameCandidates = new ArrayList<>();
+
+        if (hasText(firstName)) nameCandidates.add(firstName);
+        if (hasText(lastName)) nameCandidates.add(lastName);
+
+        if (hasText(firstName) && hasText(lastName)) {
+            nameCandidates.add(firstName + lastName);
+            nameCandidates.add(firstName + " " + lastName);
+            nameCandidates.add(lastName + firstName);
+            nameCandidates.add(lastName + " " + firstName);
+        }
+
+        String cleanMessage = message.toLowerCase().replaceAll("\\s+", " ");
+
+        for (String candidate : nameCandidates) {
+            String target = candidate.toLowerCase();
+
+            if (cleanMessage.contains(target)) return true;
+
+            if (target.length() >= 3) {
+                if (containsFuzzyMatch(cleanMessage, target)) return true;
+            }
+        }
+        return false;
     }
 
-    private boolean isMentioned(String message, String name) {
-        return name != null && message.contains(name);
+    private boolean hasText(String str) {
+        return str != null && !str.isBlank();
+    }
+
+    /**
+     * 메시지 내의 단어들을 쪼개서 이름과 '비슷한지' 검사 (오타 허용)
+     */
+    private boolean containsFuzzyMatch(String message, String targetName) {
+        String[] words = message.split(" ");
+
+        for (String word : words) {
+            String strippedWord = stripKoreanParticles(word);
+            int distance = getLevenshteinDistance(strippedWord, targetName);
+            int threshold = (targetName.length() > 5) ? 2 : 1;
+
+            if (distance <= threshold) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * 한국어 조사 제거 (아/야/님/이/가 등)
+     * 예: "도현아" -> "도현", "도현님" -> "도현"
+     */
+    private String stripKoreanParticles(String word) {
+        if (word == null || word.length() < 2) return word;
+        // 끝글자가 조사인지 확인하고 자름
+        if (word.endsWith("아") || word.endsWith("야") || word.endsWith("님") || word.endsWith("이")) {
+            return word.substring(0, word.length() - 1);
+        }
+        return word;
+    }
+
+    /**
+     * 레벤슈타인 거리 알고리즘 (두 문자열의 차이 계산)
+     * - 외부 라이브러리(Apache Commons) 없이 구현
+     */
+    private int getLevenshteinDistance(String s1, String s2) {
+        int[] costs = new int[s2.length() + 1];
+        for (int j = 0; j < costs.length; j++) costs[j] = j;
+        for (int i = 1; i <= s1.length(); i++) {
+            costs[0] = i;
+            int nw = i - 1;
+            for (int j = 1; j <= s2.length(); j++) {
+                int cj = Math.min(1 + Math.min(costs[j], costs[j - 1]),
+                        s1.charAt(i - 1) == s2.charAt(j - 1) ? nw : nw + 1);
+                nw = costs[j];
+                costs[j] = cj;
+            }
+        }
+        return costs[s2.length()];
     }
 
     private long calculateThinkingTime(String userMessage) {

--- a/src/main/java/core/domain/ai/service/AiChatUserService.java
+++ b/src/main/java/core/domain/ai/service/AiChatUserService.java
@@ -9,6 +9,7 @@ import core.domain.chat.dto.SendMessageRequest;
 import core.domain.chat.entity.ChatMessage;
 import core.domain.chat.entity.ChatRoom;
 import core.domain.chat.repository.ChatMessageRepository;
+import core.domain.chat.repository.ChatRoomRepository;
 import core.domain.chat.service.ChatMessageService;
 import core.domain.user.entity.User;
 import core.global.enums.MessageType;
@@ -45,6 +46,7 @@ public class AiChatUserService {
     private final ChatMessageService chatMessageService;
     private final AiPersonaRepository aiPersonaRepository;
     private final ChatMessageRepository chatMessageRepository;
+    private final ChatRoomRepository chatRoomRepository;
     private final AiClient aiClient;
     private static final SecureRandom secureRandom = new SecureRandom();
 
@@ -65,7 +67,8 @@ public class AiChatUserService {
 
         // 2. [No DB] 사람처럼 생각하는 척 대기 (Thread Sleep)
         // 이 구간에서 DB 커넥션을 물고 있으면 안 됨 -> 트랜잭션 없음 OK
-        long thinkingTime = calculateThinkingTime(combinedUserMessage);
+        boolean isGroupChat = chatRoomRepository.isGroupChat(chatRoomId);
+        long thinkingTime = calculateThinkingTime(combinedUserMessage,isGroupChat);
         sleep(thinkingTime);
 
         // 3. [DB Read Transaction] 대화 컨텍스트 준비
@@ -174,6 +177,7 @@ public class AiChatUserService {
 
         // 5. 일반 평서문일 때 확률 상향 (5% -> 15%)
         // 너무 높으면 AI끼리만 떠들 수 있으니 적당히 올림
+
         return secureRandom.nextInt(100) < 15;
     }
     /**

--- a/src/main/java/core/domain/ai/service/AiChatUserService.java
+++ b/src/main/java/core/domain/ai/service/AiChatUserService.java
@@ -274,11 +274,23 @@ public class AiChatUserService {
         return costs[s2.length()];
     }
 
-    private long calculateThinkingTime(String userMessage) {
+    /**
+     * ⏱️ 생각하는 시간 계산
+     * - 1:1 채팅: 빠릿하게 반응 (0.5 ~ 1.5초)
+     * - 그룹 채팅: 서로 겹치지 않게 텀을 길게 둠 (2초 ~ 12초 랜덤)
+     */
+    private long calculateThinkingTime(String userMessage, boolean isGroupChat) {
         long baseDelay = 500;
-        long typingDelay = userMessage.length() * 100L; // 글자당 0.1초
-        long randomJitter = secureRandom.nextLong(100, 1000);
-        return baseDelay + typingDelay + randomJitter;
+        long typingDelay = userMessage.length() * 50L; // 글자당 0.05초 (조금 더 빠르게)
+
+        if (isGroupChat) {
+            long randomDelay = secureRandom.nextLong(2000, 12000);
+            return baseDelay + typingDelay + randomDelay;
+        } else {
+
+            long randomJitter = secureRandom.nextLong(100, 1000);
+            return baseDelay + typingDelay + randomJitter;
+        }
     }
 
     private void sleep(long millis) {

--- a/src/main/java/core/domain/ai/service/AiChatUserService.java
+++ b/src/main/java/core/domain/ai/service/AiChatUserService.java
@@ -216,8 +216,8 @@ public class AiChatUserService {
 
             if (cleanMessage.contains(target)) return true;
 
-            if (target.length() >= 3) {
-                if (containsFuzzyMatch(cleanMessage, target)) return true;
+            if (target.length() >= 3 && containsFuzzyMatch(cleanMessage, target)) {
+                return true;
             }
         }
         return false;

--- a/src/main/java/core/domain/ai/service/AiOnboardingService.java
+++ b/src/main/java/core/domain/ai/service/AiOnboardingService.java
@@ -70,25 +70,42 @@ public class AiOnboardingService {
         }
     }
 
+    // [Refactored] 메인 메서드: 흐름이 한눈에 보이도록 단순화 (복잡도 대폭 감소)
     private void processUserOnboarding(User user, List<User> allAiCharacters, Instant now) {
-        // 1. 프로필 미완성 유저는 제외
-        if (!this.isProfileComplete(user)) return;
-
-        // 2. 가입 후 흐른 시간 (분)
         long minutesSinceJoined = Duration.between(user.getCreatedAt(), now).toMinutes();
 
-        // 3. 최근 활동 여부 체크 (가입 48시간 이후인 유저에게만 적용)
-        if (minutesSinceJoined > INITIAL_ONBOARDING_MINUTES) {
-            Instant activeThreshold = now.minus(Duration.ofDays(ACTIVE_USER_THRESHOLD_DAYS));
-            // lastLoginAt이 없거나(null), 1주일보다 오래전이면 스킵
-            if (user.getLastSeenAt() == null || user.getLastSeenAt().isBefore(activeThreshold)) {
-                return;
-            }
+        // 1. 유효성 검사 (프로필, 최근 활동)
+        if (!isValidUserForOnboarding(user, minutesSinceJoined, now)) {
+            return;
         }
 
-        // ---------------------------------------------------------------
-        // ✅ [통합 스케줄링 시뮬레이션]
-        // ---------------------------------------------------------------
+        // 2. 시뮬레이션: 지금까지 몇 명의 AI가 말을 걸었어야 하는지 계산
+        int expectedAiCount = calculateExpectedAiCount(user, minutesSinceJoined);
+        long currentAiCount = chatRoomRepository.countAiChatRoomsByUser(user.getId());
+
+        // 3. 메시지 전송 시도 (조건 충족 시)
+        if (currentAiCount < expectedAiCount) {
+            trySendNewAiMessage(user, allAiCharacters, currentAiCount, minutesSinceJoined);
+        }
+    }
+
+    // [Sub-Method 1] 유저가 메시지를 받을 자격이 있는지 검사
+    private boolean isValidUserForOnboarding(User user, long minutesSinceJoined, Instant now) {
+        if (!this.isProfileComplete(user)) {
+            return false;
+        }
+
+        // 가입 48시간 이후인 경우, 최근 활동(1주일 이내)이 있어야 함
+        if (minutesSinceJoined > INITIAL_ONBOARDING_MINUTES) {
+            Instant activeThreshold = now.minus(Duration.ofDays(ACTIVE_USER_THRESHOLD_DAYS));
+            return user.getLastSeenAt() != null && !user.getLastSeenAt().isBefore(activeThreshold);
+        }
+
+        return true;
+    }
+
+    // [Sub-Method 2] 복잡했던 while 루프 계산 로직 분리
+    private int calculateExpectedAiCount(User user, long minutesSinceJoined) {
         int expectedAiCount = 0;
         long simulatedTime = 0;
 
@@ -97,11 +114,11 @@ public class AiOnboardingService {
 
             if (simulatedTime < INITIAL_ONBOARDING_MINUTES) {
                 // [Phase 1] 초기 48시간
-                long seed = user.getId() + ((long) expectedAiCount * 997L);
+                long seed = user.getId() + (expectedAiCount * 997L);
                 Random seededRandom = new Random(seed);
-                interval = 5 + seededRandom.nextInt(11);
+                interval = 5L + seededRandom.nextInt(11);
             } else {
-                // [Phase 2] 48시간 이후 ~ 3주
+                // [Phase 2] 48시간 이후
                 interval = EXTENDED_INTERVAL_MINUTES;
             }
 
@@ -112,36 +129,31 @@ public class AiOnboardingService {
             }
             expectedAiCount++;
         }
-        // ---------------------------------------------------------------
+        return expectedAiCount;
+    }
 
-        // 현재 이 유저와 대화 중인(방이 만들어진) AI 수 조회
-        long currentAiCount = chatRoomRepository.countAiChatRoomsByUser(user.getId());
+    // [Sub-Method 3] 스팸 검사 및 실제 메시지 전송 로직 분리
+    private void trySendNewAiMessage(User user, List<User> allAiCharacters, long currentAiCount, long minutesSinceJoined) {
+        // 🚨 스팸 방지: 답장 안 한 방이 5개 이상이면 중단
+        long unrepliedRoomCount = chatRoomRepository.countUnrepliedAiRooms(user.getId());
+        if (unrepliedRoomCount >= 5) {
+            log.info("🚫 User[{}] ignores too many AIs ({}). Skip onboarding.", user.getId(), unrepliedRoomCount);
+            return;
+        }
 
-        // 로직상 보내야 할 AI 수보다, 실제로 만난 AI 수가 적다면 -> "새로운 AI 출동!"
-        if (currentAiCount < expectedAiCount) {
+        // 모든 AI 소진 체크
+        if (currentAiCount >= allAiCharacters.size()) {
+            return;
+        }
 
-            // ▼▼▼▼▼▼▼▼▼▼▼▼▼▼ [여기 추가하세요] ▼▼▼▼▼▼▼▼▼▼▼▼▼▼
-            // 🚨 스팸 방지: 유저가 답장 안 한 방이 5개 이상이면, 타이밍이 맞아도 안 보냄
-            long unrepliedRoomCount = chatRoomRepository.countUnrepliedAiRooms(user.getId());
-            if (unrepliedRoomCount >= 5) {
-                log.info("🚫 User[{}] ignores too many AIs ({}). Skip onboarding.", user.getId(), unrepliedRoomCount);
-                return; // 여기서 함수 종료 (이번 턴은 쉽니다)
-            }
-            // ▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
-
-            // 모든 AI를 다 만났으면 더 이상 못 보냄
-            if (currentAiCount >= allAiCharacters.size()) return;
-
-            // 아직 대화 안 해본 AI 찾기
-            User selectedAi = findUnusedAi(user, allAiCharacters);
-
-            if (selectedAi != null) {
-                createRoomAndSendFirstMessage(user, selectedAi);
-                log.info("✅ Auto Msg Sent: AI[{}] -> User[{}] (Joined: {}m, Phase: {})",
-                        selectedAi.getFirstName(), user.getFirstName(),
-                        minutesSinceJoined,
-                        (minutesSinceJoined <= INITIAL_ONBOARDING_MINUTES) ? "Initial(48h)" : "Extended(3w)");
-            }
+        // 안 만난 AI 찾기 및 전송
+        User selectedAi = findUnusedAi(user, allAiCharacters);
+        if (selectedAi != null) {
+            createRoomAndSendFirstMessage(user, selectedAi);
+            log.info("✅ Auto Msg Sent: AI[{}] -> User[{}] (Joined: {}m, Phase: {})",
+                    selectedAi.getFirstName(), user.getFirstName(),
+                    minutesSinceJoined,
+                    (minutesSinceJoined <= INITIAL_ONBOARDING_MINUTES) ? "Initial(48h)" : "Extended(3w)");
         }
     }
 

--- a/src/main/java/core/domain/ai/service/AiOnboardingService.java
+++ b/src/main/java/core/domain/ai/service/AiOnboardingService.java
@@ -88,33 +88,28 @@ public class AiOnboardingService {
 
         // ---------------------------------------------------------------
         // ✅ [통합 스케줄링 시뮬레이션]
-        // 가입 시점부터 현재까지 타임라인을 돌려보며 "지금까지 총 몇 명의 AI가 말을 걸었어야 하는지" 계산
         // ---------------------------------------------------------------
         int expectedAiCount = 0;
-        long simulatedTime = 0; // 가입 직후(0분)부터 시작
+        long simulatedTime = 0;
 
         while (true) {
             long interval;
 
             if (simulatedTime < INITIAL_ONBOARDING_MINUTES) {
-                // [Phase 1] 초기 48시간: 5~15분 간격 (랜덤)
-                // Seed를 고정하여 서버가 언제 돌든 유저별로 동일한 패턴 유지
+                // [Phase 1] 초기 48시간
                 long seed = user.getId() + (expectedAiCount * 997L);
                 Random seededRandom = new Random(seed);
                 interval = 5 + seededRandom.nextInt(11);
             } else {
-                // [Phase 2] 48시간 이후 ~ 3주: 2시간(120분) 고정 간격
+                // [Phase 2] 48시간 이후 ~ 3주
                 interval = EXTENDED_INTERVAL_MINUTES;
             }
 
             simulatedTime += interval;
 
-            // 시뮬레이션 시간이 실제 흐른 시간을 넘어서면 루프 종료
             if (simulatedTime > minutesSinceJoined) {
                 break;
             }
-
-            // 이 시점까지는 메시지를 보냈어야 함 -> 카운트 증가
             expectedAiCount++;
         }
         // ---------------------------------------------------------------
@@ -124,6 +119,15 @@ public class AiOnboardingService {
 
         // 로직상 보내야 할 AI 수보다, 실제로 만난 AI 수가 적다면 -> "새로운 AI 출동!"
         if (currentAiCount < expectedAiCount) {
+
+            // ▼▼▼▼▼▼▼▼▼▼▼▼▼▼ [여기 추가하세요] ▼▼▼▼▼▼▼▼▼▼▼▼▼▼
+            // 🚨 스팸 방지: 유저가 답장 안 한 방이 5개 이상이면, 타이밍이 맞아도 안 보냄
+            long unrepliedRoomCount = chatRoomRepository.countUnrepliedAiRooms(user.getId());
+            if (unrepliedRoomCount >= 5) {
+                log.info("🚫 User[{}] ignores too many AIs ({}). Skip onboarding.", user.getId(), unrepliedRoomCount);
+                return; // 여기서 함수 종료 (이번 턴은 쉽니다)
+            }
+            // ▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
 
             // 모든 AI를 다 만났으면 더 이상 못 보냄
             if (currentAiCount >= allAiCharacters.size()) return;

--- a/src/main/java/core/domain/ai/service/AiOnboardingService.java
+++ b/src/main/java/core/domain/ai/service/AiOnboardingService.java
@@ -97,7 +97,7 @@ public class AiOnboardingService {
 
             if (simulatedTime < INITIAL_ONBOARDING_MINUTES) {
                 // [Phase 1] 초기 48시간
-                long seed = user.getId() + (expectedAiCount * 997L);
+                long seed = user.getId() + ((long) expectedAiCount * 997L);
                 Random seededRandom = new Random(seed);
                 interval = 5 + seededRandom.nextInt(11);
             } else {

--- a/src/main/java/core/domain/ai/service/AiOnboardingService.java
+++ b/src/main/java/core/domain/ai/service/AiOnboardingService.java
@@ -7,20 +7,18 @@ import core.domain.chat.service.ChatMessageService;
 import core.domain.chat.service.ChatRoomService;
 import core.domain.user.entity.User;
 import core.domain.user.repository.UserRepository;
-import core.domain.user.service.UserRoleDetectService;
 import core.global.entity.image.service.ImageService;
 import core.global.enums.MessageType;
 import core.global.enums.Role;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-// import org.springframework.transaction.annotation.Transactional; // 성능을 위해 제거 (필요시 개별 메서드에 적용)
 
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
-import java.util.Random; // ✅ 랜덤 간격 계산용 추가
+import java.util.Random;
 
 @Slf4j
 @Service
@@ -28,93 +26,118 @@ import java.util.Random; // ✅ 랜덤 간격 계산용 추가
 public class AiOnboardingService {
 
     private final ImageService imageService;
-    private final UserRoleDetectService userRoleDetectService;
     private final UserRepository userRepository;
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageService chatMessageService;
     private final ChatRoomService chatRoomService;
 
-    // 메시지 문구 랜덤 선택용 (보안 강도 높음)
+    // 메시지 문구 랜덤 선택용
     private static final SecureRandom secureRandom = new SecureRandom();
 
-    // ✅ [설정 변경] 가입 후 24시간(1440분) 동안 동작
-    private static final int ONBOARDING_WINDOW_MINUTES = 1440;
+    // 1. 초기 온보딩 기간: 가입 후 48시간 (2880분)
+    private static final int INITIAL_ONBOARDING_MINUTES = 48 * 60; // 2880분
+
+    // 2. 확장 참여 유도 기간: 가입 후 3주 (21일)
+    private static final int EXTENDED_WINDOW_DAYS = 21;
+
+    // 3. 활동 유저 기준: 최근 1주일 (7일) 내 접속
+    private static final int ACTIVE_USER_THRESHOLD_DAYS = 7;
+
+    // 4. 확장 기간 중 메시지 발송 간격: 2시간 (120분)
+    private static final int EXTENDED_INTERVAL_MINUTES = 120;
 
     /**
-     * 주기적으로 실행되어 신규 유저에게 AI가 선톡을 보냄
-     * (전체 트랜잭션 제거하여 DB 잠금 최소화)
+     * 주기적으로 실행되어 조건에 맞는 유저에게 AI가 선톡을 보냄
      */
     public void sendWelcomeMessagesToNewUsers() {
         Instant now = Instant.now();
-        Instant timeLimit = now.minus(Duration.ofMinutes(ONBOARDING_WINDOW_MINUTES));
 
-        // 가입한 지 24시간 이내인 유저 조회
-        List<User> newUsers = userRepository.findByUserRoleAndCreatedAtAfter(Role.USER, timeLimit);
+        // 검색 범위: 가입한 지 3주(21일) 이내인 유저 전체 조회
+        Instant joinTimeLimit = now.minus(Duration.ofDays(EXTENDED_WINDOW_DAYS));
+
+        // 쿼리 최적화: Role이 USER이고, createdAt이 3주 이내인 사람만 fetch
+        List<User> targetUsers = userRepository.findByUserRoleAndCreatedAtAfter(Role.USER, joinTimeLimit);
         List<User> allAiCharacters = userRepository.findByUserRole(Role.AI);
 
         if (allAiCharacters.isEmpty()) return;
 
-        for (User user : newUsers) {
+        for (User user : targetUsers) {
             try {
                 processUserOnboarding(user, allAiCharacters, now);
             } catch (Exception e) {
-                log.error("Failed onboarding for user: {}", user.getId(), e);
+                log.error("Failed onboarding process for user: {}", user.getId(), e);
             }
         }
     }
 
     private void processUserOnboarding(User user, List<User> allAiCharacters, Instant now) {
-        if (!this.isProfileComplete(user)) {
-            return;
-        }
+        // 1. 프로필 미완성 유저는 제외
+        if (!this.isProfileComplete(user)) return;
 
-        // 가입 후 흐른 시간 (분)
+        // 2. 가입 후 흐른 시간 (분)
         long minutesSinceJoined = Duration.between(user.getCreatedAt(), now).toMinutes();
 
+        // 3. 최근 활동 여부 체크 (가입 48시간 이후인 유저에게만 적용)
+        if (minutesSinceJoined > INITIAL_ONBOARDING_MINUTES) {
+            Instant activeThreshold = now.minus(Duration.ofDays(ACTIVE_USER_THRESHOLD_DAYS));
+            // lastLoginAt이 없거나(null), 1주일보다 오래전이면 스킵
+            if (user.getLastSeenAt() == null || user.getLastSeenAt().isBefore(activeThreshold)) {
+                return;
+            }
+        }
+
         // ---------------------------------------------------------------
-        // ✅ [핵심 로직 변경] 유저별 고유 랜덤 스케줄 계산 (5~15분 간격)
+        // ✅ [통합 스케줄링 시뮬레이션]
+        // 가입 시점부터 현재까지 타임라인을 돌려보며 "지금까지 총 몇 명의 AI가 말을 걸었어야 하는지" 계산
         // ---------------------------------------------------------------
         int expectedAiCount = 0;
-        long accumulatedTime = 0;
+        long simulatedTime = 0; // 가입 직후(0분)부터 시작
 
-        // "현재 시간까지 이 유저에게 몇 명의 AI가 말을 걸었어야 정상인가?"를 계산
         while (true) {
-            // Seed를 고정하여, 서버가 재시작되거나 스케줄러가 다시 돌아도
-            // '이 유저의 N번째 AI 도착 시간'은 항상 똑같이 계산됨 (Deterministic Random)
-            long seed = user.getId() + (expectedAiCount * 997L);
-            Random seededRandom = new Random(seed);
+            long interval;
 
-            // 5분 ~ 15분 사이 랜덤 값 추출 (5 + 0~10)
-            long nextInterval = 5 + seededRandom.nextInt(11);
+            if (simulatedTime < INITIAL_ONBOARDING_MINUTES) {
+                // [Phase 1] 초기 48시간: 5~15분 간격 (랜덤)
+                // Seed를 고정하여 서버가 언제 돌든 유저별로 동일한 패턴 유지
+                long seed = user.getId() + (expectedAiCount * 997L);
+                Random seededRandom = new Random(seed);
+                interval = 5 + seededRandom.nextInt(11);
+            } else {
+                // [Phase 2] 48시간 이후 ~ 3주: 2시간(120분) 고정 간격
+                interval = EXTENDED_INTERVAL_MINUTES;
+            }
 
-            accumulatedTime += nextInterval;
+            simulatedTime += interval;
 
-            // 누적 시간이 가입 후 흐른 시간을 넘어서면, 아직 보낼 때가 아님 -> 루프 종료
-            if (accumulatedTime > minutesSinceJoined) {
+            // 시뮬레이션 시간이 실제 흐른 시간을 넘어서면 루프 종료
+            if (simulatedTime > minutesSinceJoined) {
                 break;
             }
 
-            // 보낼 시간이 지났으면 카운트 증가
+            // 이 시점까지는 메시지를 보냈어야 함 -> 카운트 증가
             expectedAiCount++;
         }
         // ---------------------------------------------------------------
 
-        // 현재 이 유저와 대화 중인 AI 수 조회
+        // 현재 이 유저와 대화 중인(방이 만들어진) AI 수 조회
         long currentAiCount = chatRoomRepository.countAiChatRoomsByUser(user.getId());
 
-        // 이미 충분히 받았다면 스킵
-        if (currentAiCount >= expectedAiCount) return;
+        // 로직상 보내야 할 AI 수보다, 실제로 만난 AI 수가 적다면 -> "새로운 AI 출동!"
+        if (currentAiCount < expectedAiCount) {
 
-        // 보유한 AI 캐릭터 수보다 더 많이 보낼 순 없음
-        if (currentAiCount >= allAiCharacters.size()) return;
+            // 모든 AI를 다 만났으면 더 이상 못 보냄
+            if (currentAiCount >= allAiCharacters.size()) return;
 
-        // 안 만난 AI 찾아서 매칭
-        User selectedAi = findUnusedAi(user, allAiCharacters);
+            // 아직 대화 안 해본 AI 찾기
+            User selectedAi = findUnusedAi(user, allAiCharacters);
 
-        if (selectedAi != null) {
-            createRoomAndSendFirstMessage(user, selectedAi);
-            log.info("✅ Onboarding Msg Sent: AI[{}] -> User[{}] (Joined: {}m, Target: {}th)",
-                    selectedAi.getFirstName(), user.getFirstName(), minutesSinceJoined, expectedAiCount);
+            if (selectedAi != null) {
+                createRoomAndSendFirstMessage(user, selectedAi);
+                log.info("✅ Auto Msg Sent: AI[{}] -> User[{}] (Joined: {}m, Phase: {})",
+                        selectedAi.getFirstName(), user.getFirstName(),
+                        minutesSinceJoined,
+                        (minutesSinceJoined <= INITIAL_ONBOARDING_MINUTES) ? "Initial(48h)" : "Extended(3w)");
+            }
         }
     }
 
@@ -143,21 +166,18 @@ public class AiOnboardingService {
         try {
             chatMessageService.processAndSendChatMessage(request);
         } catch (Exception e) {
-            log.error("❌ Failed to send AI onboarding message via pipeline", e);
+            log.error("❌ Failed to send AI onboarding message", e);
         }
     }
 
     private String generateWelcomeMessage() {
         String[] greetings = {
-                // 기존 문구
                 "Hi! Just bored so I thought I'd say hello lol",
                 "Your profile looks cool! Nice to meet you.",
                 "Are you studying Korean? We can practice together.",
                 "Do you like K-pop? Who's your favorite group?",
                 "Hi there! How is your day going?",
                 "Hi, I'm from Korea! Where are you from?",
-
-                // 추가된 문구
                 "Hey! How's it going?",
                 "Hi! Hope you're having a good week.",
                 "Hello! Just wanted to say hi.",

--- a/src/main/java/core/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/core/domain/chat/repository/ChatMessageRepository.java
@@ -119,6 +119,6 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long>,
     Long countSendMessageUsersLast1Day();
 
     Page<ChatMessage> findAllByChatRoomId(Long chatRoomId, Pageable pageable);
-
+    @Query("SELECT m FROM ChatMessage m JOIN FETCH m.chatRoom WHERE m.chatRoom.id = :chatRoomId ORDER BY m.sentAt DESC")
     List<ChatMessage> findTop20ByChatRoomIdOrderBySentAtDesc(Long chatRoomId);
 }

--- a/src/main/java/core/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/core/domain/chat/repository/ChatRoomRepository.java
@@ -123,4 +123,7 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long>, ChatR
     List<ChatRoom> findByIsGroupTrue();
     @Query("SELECT c.isGroup FROM ChatRoom c WHERE c.id = :roomId")
     boolean isGroupChat(@Param("roomId") Long roomId);
+
+    @Query("SELECT COUNT(c) FROM ChatRoom c WHERE c.id = :userId AND c.lastSenderId != :userId")
+    long countUnrepliedAiRooms(@Param("userId") Long userId);
 }

--- a/src/main/java/core/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/core/domain/chat/repository/ChatRoomRepository.java
@@ -124,6 +124,10 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long>, ChatR
     @Query("SELECT c.isGroup FROM ChatRoom c WHERE c.id = :roomId")
     boolean isGroupChat(@Param("roomId") Long roomId);
 
-    @Query("SELECT COUNT(c) FROM ChatRoom c WHERE c.id = :userId AND c.lastSenderId != :userId")
+    @Query("SELECT COUNT(c) FROM ChatRoom c " +
+            "JOIN c.participants p " +
+            "WHERE p.user.id = :userId " +
+            "AND c.isGroup = false " +
+            "AND (SELECT COUNT(m) FROM ChatMessage m WHERE m.chatRoom = c AND m.sender.id = :userId) = 0")
     long countUnrepliedAiRooms(@Param("userId") Long userId);
 }

--- a/src/main/java/core/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/core/domain/chat/repository/ChatRoomRepository.java
@@ -121,4 +121,6 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long>, ChatR
     long countAiChatRoomsByUser(@Param("userId") Long userId);
 
     List<ChatRoom> findByIsGroupTrue();
+    @Query("SELECT c.isGroup FROM ChatRoom c WHERE c.id = :roomId")
+    boolean isGroupChat(@Param("roomId") Long roomId);
 }

--- a/src/main/java/core/domain/chat/service/ChatMemberService.java
+++ b/src/main/java/core/domain/chat/service/ChatMemberService.java
@@ -106,23 +106,38 @@ public class ChatMemberService {
         }
         blockRepository.save(new BlockUser(blocker, blockedUser));
     }
-
     @Transactional
     public void reportChat(Long reporterUserId, ChatReportRequest request) {
-        if (chatReportRepository.existsByReporterUserIdAndMessageId(reporterUserId, request.messageId())) {
-            throw new BusinessException(ChatErrorCode.DUPLICATE_REPORT);
+
+        User reporterUser = null;
+
+        // 1. [수정] 신고자가 사람(User)일 때만 유효성 검사 수행
+        if (reporterUserId != null) {
+            // 중복 신고 체크
+            if (chatReportRepository.existsByReporterUserIdAndMessageId(reporterUserId, request.messageId())) {
+                throw new BusinessException(ChatErrorCode.DUPLICATE_REPORT);
+            }
+
+            // 신고자 조회
+            reporterUser = userRepository.findById(reporterUserId)
+                    .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
         }
-        User reporterUser = userRepository.findById(reporterUserId)
-                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        // 2. 신고 대상 메시지 조회
         ChatMessage reportedMessage = chatMessageRepository.findById(request.messageId())
                 .orElseThrow(() -> new BusinessException(ChatErrorCode.MESSAGE_NOT_FOUND));
+
         User reportedUser = reportedMessage.getSender();
         ChatRoom chatRoom = reportedMessage.getChatRoom();
-        if (reportedUser.getId().equals(reporterUserId)) {
+
+        // 3. [수정] 자진 신고 방지 (신고자가 있을 때만 체크)
+        if (reporterUserId != null && reportedUser.getId().equals(reporterUserId)) {
             throw new BusinessException(ChatErrorCode.CANNOT_REPORT_SELF);
         }
+
+        // 4. 리포트 생성 (reporterUser가 null이면 시스템 신고로 저장)
         ChatReport chatReport = new ChatReport(
-                reporterUser,
+                reporterUser, // 여기가 null이어도 들어가도록 허용
                 reportedUser,
                 chatRoom,
                 request.messageId(),
@@ -130,9 +145,9 @@ public class ChatMemberService {
                 request.reasonCategory(),
                 request.reasonDetail()
         );
+
         chatReportRepository.save(chatReport);
     }
-
     // --- 설정 (번역, 알림) ---
 
     @Transactional

--- a/src/main/java/core/domain/notification/service/NotificationEventListener.java
+++ b/src/main/java/core/domain/notification/service/NotificationEventListener.java
@@ -136,7 +136,10 @@ public class NotificationEventListener {
     @Async
     @EventListener
     public void handleBulkNotification(NotificationBulkEvent event) {
+        String safeMessage = truncate(event.content(), 100);
+
         User senderProxy = entityManager.getReference(User.class, event.senderId());
+
         List<Notification> notifications = event.recipientIds().stream()
                 .map(targetId -> {
                     User receiverProxy = entityManager.getReference(User.class, targetId);
@@ -144,12 +147,13 @@ public class NotificationEventListener {
                     try {
                         referenceId = Long.parseLong(String.valueOf(event.roomId()));
                     } catch (NumberFormatException e) {
+                        // ignore
                     }
 
                     return Notification.builder()
                             .user(receiverProxy)
                             .actor(senderProxy)
-                            .message(event.content())
+                            .message(safeMessage)
                             .notificationType(event.type())
                             .referenceId(referenceId)
                             .subReferenceId(null)
@@ -157,10 +161,14 @@ public class NotificationEventListener {
                 })
                 .toList();
 
-
         notificationRepository.saveAll(notifications);
+        pushNotificationService.sendGroupPush(event.recipientIds(),safeMessage, String.valueOf(event.roomId()), event.roomName(), event.senderId());
+    }
+    private String truncate(String input, int maxLength) {
+        if (input == null) return null;
+        if (input.length() <= maxLength) return input;
 
-
-        pushNotificationService.sendGroupPush(event.recipientIds(), event.content(), String.valueOf(event.roomId()), event.roomName(), event.senderId());
+        // 3글자("...") 공간을 확보하기 위해 -3
+        return input.substring(0, maxLength - 3) + "...";
     }
 }


### PR DESCRIPTION
# 📄 PR 변경사항

* **AI 멘션 인식 고도화:** 오타가 있어도 이름을 인식하도록 퍼지 매칭(Fuzzy Matching) 적용
* **그룹 채팅 반응성 개선:** AI가 답변을 생성하는 도중 다른 사람이 말하면 맥락을 재확인하도록 로직 수정
* **온보딩 정책 변경:** 초기 집중 공략 기간 확대(24h → 48h) 및 대상 유저 확대(가입 3주 이내)
* **스팸 방지(Cap) 추가:** 유저가 답장하지 않은 AI 채팅방이 5개 이상이면 선톡 중단
* **버그 수정:** 자동 신고 시 reporterId 누락 수정 및 알림 텍스트 길이 초과 방지

# 🖌️ 구체적인 구현 내용

**1. AI 대화 엔진 개선 (`AiChatUserService`)**

* **퍼지 매칭 도입:** 레벤슈타인 거리 알고리즘을 사용하여 유저가 AI 이름을 약간 틀리게 불러도(오타) 인식하여 대답하도록 개선했습니다.
* **Context Awareness:** AI가 `sleep` 후 답변을 보내기 직전, `originalMessageId`와 현재 최신 메시지를 비교하여 그사이 대화 흐름이 바뀌었는지 감지하고 프롬프트에 반영합니다.

**2. 온보딩 스팸 방지 (`AiOnboardingService`, `ChatRoomRepository`)**

* **Stacking Limit:** `countUnrepliedAiRooms` 쿼리를 추가하여, 현재 유저가 읽고 답장하지 않은(메시지 수 0) AI 방이 5개 이상이면 온보딩 스케줄링을 건너뛰도록 구현했습니다.
* **기간 조정:** 초기 가입 유저의 이탈을 막기 위해 촘촘한 간격의 메시지 발송 기간을 48시간으로 늘리고, 기존 가입자(3주 이내)도 로직에 포함시켰습니다.

**3. 안정성 및 버그 수정**

* **Notification:** 알림 내용이 너무 길어 DB 컬럼 사이즈를 초과할 경우 트랜잭션이 롤백되는 문제를 해결했습니다.
* **Report:** 시스템에 의한 자동 신고 처리 시 `reporterId`가 null이라 발생하던 예외를 수정했습니다.

# ✨개선 사항 및 참고 사항
#520 
#521 
#515
#512

주석은 지우지 않았습니다.
주석이 있어야 개선 및 참고할때 속도가 더 붙는 상황입니다.
추후에 완전히 ai 채팅 개선 및 완료가 되면 한 번에 정리하겠습니다.

# 💯 테스트


