### PR TITLE
메인 콘텐츠 단건 조회 API 구현

### DIFF
--- a/src/main/java/core/domain/maincontent/controller/MainContentController.java
+++ b/src/main/java/core/domain/maincontent/controller/MainContentController.java
@@ -2,9 +2,8 @@ package core.domain.maincontent.controller;
 
 import core.domain.maincontent.dto.MainPageContentResponse;
 import core.domain.maincontent.service.MainContentService;
-import core.global.docs.annotations.CommonErrorCodeDocs;
+
 import core.global.docs.annotations.MainContentErrorDocs;
-import core.global.enums.errorcode.CommonErrorCode;
 import core.global.enums.errorcode.MainContentErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;

--- a/src/main/java/core/domain/maincontent/controller/MainContentController.java
+++ b/src/main/java/core/domain/maincontent/controller/MainContentController.java
@@ -1,0 +1,45 @@
+package core.domain.maincontent.controller;
+
+import core.domain.maincontent.dto.MainPageContentResponse;
+import core.domain.maincontent.service.MainContentService;
+import core.global.docs.annotations.CommonErrorCodeDocs;
+import core.global.docs.annotations.MainContentErrorDocs;
+import core.global.enums.errorcode.CommonErrorCode;
+import core.global.enums.errorcode.MainContentErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v2/main-contents") // 기본 경로 설정
+@RequiredArgsConstructor
+public class MainContentController {
+
+    private final MainContentService mainContentService;
+
+    /**
+     * 메인 콘텐츠 단건 조회 API
+     * URL: GET /api/v1/main-contents/{contentId}
+     */
+    @Operation(summary = "메인 콘텐츠 단건 조회", description = "콘텐츠 ID(pk)를 이용하여 메인 페이지에 표시될 콘텐츠의 상세 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 콘텐츠 ID")
+    })
+    @GetMapping("/{contentId}")
+    @MainContentErrorDocs({MainContentErrorCode.CONTENT_NOT_FOUND})
+    public ResponseEntity<MainPageContentResponse> getMainContent(
+            @Parameter(description = "조회할 콘텐츠의 ID", required = true, example = "1")
+            @PathVariable Long contentId
+    ) {
+        MainPageContentResponse response = mainContentService.getMainContent(contentId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/core/domain/maincontent/dto/MainPageContentResponse.java
+++ b/src/main/java/core/domain/maincontent/dto/MainPageContentResponse.java
@@ -1,0 +1,20 @@
+package core.domain.maincontent.dto;
+
+import core.domain.maincontent.entity.MainPageContent;
+
+
+public record MainPageContentResponse(
+        Long id,
+        String title,
+        String htmlContent,
+        String originalUrl
+) {
+    public static MainPageContentResponse from(MainPageContent entity) {
+        return new MainPageContentResponse(
+                entity.getId(),
+                entity.getTitle(),
+                entity.getHtmlContent(),
+                entity.getOriginalUrl()
+        );
+    }
+}

--- a/src/main/java/core/domain/maincontent/entity/MainPageContent.java
+++ b/src/main/java/core/domain/maincontent/entity/MainPageContent.java
@@ -35,9 +35,6 @@ public class MainPageContent {
     @Column(name = "original_url")
     private String originalUrl;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "publisher_id")
-    private User publisher;
 
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
@@ -47,15 +44,12 @@ public class MainPageContent {
     @Column(name = "updated_at")
     private Instant updatedAt;
 
-//    @OneToMany(mappedBy = "mainPageContent", orphanRemoval = true, cascade = CascadeType.ALL)
-//    private List<Comment> comments = new ArrayList<>();
 
     @Builder
-    public MainPageContent(String title, String htmlContent, String originalUrl, User publisher) {
+    public MainPageContent(String title, String htmlContent, String originalUrl) {
         this.title = title;
         this.htmlContent = htmlContent;
         this.originalUrl = originalUrl;
-        this.publisher = publisher;
     }
 
     public void changeHtmlContent(String htmlContent) {

--- a/src/main/java/core/domain/maincontent/repository/MainContentRepository.java
+++ b/src/main/java/core/domain/maincontent/repository/MainContentRepository.java
@@ -3,5 +3,5 @@ package core.domain.maincontent.repository;
 import core.domain.maincontent.entity.MainPageContent;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MainPageContentRepository extends JpaRepository<MainPageContent, Long> {
+public interface MainContentRepository extends JpaRepository<MainPageContent, Long> {
 }

--- a/src/main/java/core/domain/maincontent/service/MainContentService.java
+++ b/src/main/java/core/domain/maincontent/service/MainContentService.java
@@ -1,0 +1,27 @@
+package core.domain.maincontent.service;
+
+
+import core.domain.maincontent.dto.MainPageContentResponse;
+import core.domain.maincontent.entity.MainPageContent;
+import core.domain.maincontent.repository.MainContentRepository;
+import core.global.enums.errorcode.MainContentErrorCode;
+import core.global.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MainContentService {
+    private final MainContentRepository mainPageContentRepository;
+
+    public MainPageContentResponse getMainContent(Long contentId) {
+        MainPageContent content = mainPageContentRepository.findById(contentId)
+                .orElseThrow(() -> new BusinessException(MainContentErrorCode.CONTENT_NOT_FOUND));
+
+        return MainPageContentResponse.from(content);
+    }
+}

--- a/src/main/java/core/domain/maincontent/service/MainContentService.java
+++ b/src/main/java/core/domain/maincontent/service/MainContentService.java
@@ -8,10 +8,6 @@ import core.global.enums.errorcode.MainContentErrorCode;
 import core.global.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/core/domain/post/service/impl/PostServiceImpl.java
+++ b/src/main/java/core/domain/post/service/impl/PostServiceImpl.java
@@ -13,7 +13,7 @@ import core.domain.post.entity.PostReport;
 import core.domain.post.event.PostCreatedEvent;
 import core.domain.post.event.PostUpdatedEvent;
 import core.domain.post.repository.BlockPostRepository;
-import core.domain.maincontent.repository.MainPageContentRepository;
+import core.domain.maincontent.repository.MainContentRepository;
 import core.domain.post.repository.PostReportRepository;
 import core.domain.post.repository.PostRepository;
 import core.domain.post.service.PostService;
@@ -93,7 +93,7 @@ public class PostServiceImpl implements PostService {
     private final ApplicationEventPublisher eventPublisher;
     private final PostReportRepository postReportRepository;
 
-    private final MainPageContentRepository mainPageContentRepository;
+    private final MainContentRepository mainPageContentRepository;
     private final S3Client s3Client;
     private final S3Props s3Props;
 
@@ -658,7 +658,6 @@ public class PostServiceImpl implements PostService {
                     .title(title)
                     .htmlContent(content)
                     .originalUrl(null)
-                    .publisher(adminUser)
                     .build();
 
             MainPageContent savedContent = mainPageContentRepository.save(newContent);

--- a/src/main/java/core/global/docs/annotations/MainContentErrorDocs.java
+++ b/src/main/java/core/global/docs/annotations/MainContentErrorDocs.java
@@ -1,0 +1,14 @@
+package core.global.docs.annotations;
+
+import core.global.enums.errorcode.MainContentErrorCode;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MainContentErrorDocs {
+    MainContentErrorCode[] value();
+}

--- a/src/main/java/core/global/enums/errorcode/MainContentErrorCode.java
+++ b/src/main/java/core/global/enums/errorcode/MainContentErrorCode.java
@@ -1,0 +1,31 @@
+package core.global.enums.errorcode;
+
+import core.global.exception.AppError;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MainContentErrorCode implements AppError {
+
+    CONTENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 메인 콘텐츠를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String code() {
+        return name();
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/src/main/java/core/global/service/CrawledDataAdminService.java
+++ b/src/main/java/core/global/service/CrawledDataAdminService.java
@@ -8,7 +8,7 @@ import core.domain.post.entity.CrawledData;
 import core.domain.maincontent.entity.MainPageContent;
 import core.domain.post.entity.Post;
 import core.domain.post.repository.CrawledDataRepository;
-import core.domain.maincontent.repository.MainPageContentRepository;
+import core.domain.maincontent.repository.MainContentRepository;
 import core.domain.post.repository.PostRepository;
 import core.domain.user.entity.User;
 import core.domain.user.repository.UserRepository;
@@ -60,7 +60,7 @@ public class CrawledDataAdminService {
 
     private final CrawledDataRepository crawledDataRepository;
     private final PostRepository postRepository;
-    private final MainPageContentRepository mainPageContentRepository;
+    private final MainContentRepository mainPageContentRepository;
     private final UserRepository userRepository;
     private final BoardRepository boardRepository;
     private final PostImageService postImageService;
@@ -131,8 +131,7 @@ public class CrawledDataAdminService {
         } else if ("MAIN_PAGE".equals(publishType)) {
             MainPageContent newContent = MainPageContent.builder()
                     .title(title).htmlContent(content)
-                    .originalUrl(sourceDataList.get(0).getOriginalUrl())
-                    .publisher(adminUser).build();
+                    .originalUrl(sourceDataList.get(0).getOriginalUrl()).build();
             MainPageContent savedContent = mainPageContentRepository.save(newContent);
             Long contentId = savedContent.getId();
             savedReferenceId = contentId;
@@ -179,7 +178,7 @@ public class CrawledDataAdminService {
         } else if ("MAIN_PAGE".equals(publishType)) {
             MainPageContent newContent = MainPageContent.builder()
                     .title(crawledData.getTitle()).htmlContent(content)
-                    .originalUrl(crawledData.getOriginalUrl()).publisher(adminUser).build();
+                    .originalUrl(crawledData.getOriginalUrl()).build();
             MainPageContent savedContent = mainPageContentRepository.save(newContent);
             Long contentId = savedContent.getId();
             savedReferenceId = contentId;

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,11 +1,10 @@
 spring:
   flyway:
-    enabled: false
+    enabled: true
     baseline-on-migrate: true
   config:
     activate:
       on-profile: local
-
   messages:
     basename: messages
     encoding: UTF-8
@@ -51,10 +50,10 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
-    show-sql: true
+    show-sql: false
     properties:
       hibernate:
-        format_sql: true
+        format_sql: false
         dialect: org.hibernate.dialect.PostgreSQLDialect
 
 jwt:

--- a/src/main/resources/db/migration/V202512281148__alter_table_maincontent.sql
+++ b/src/main/resources/db/migration/V202512281148__alter_table_maincontent.sql
@@ -1,0 +1,4 @@
+-- main_page_content 테이블에서 publisher_id 컬럼을 삭제합니다.
+-- CASCADE 옵션을 사용하여 이 컬럼에 걸려있는 Foreign Key 제약조건도 함께 삭제합니다.
+ALTER TABLE main_page_content
+    DROP COLUMN publisher_id CASCADE;


### PR DESCRIPTION
### 제목

`feat: 메인 콘텐츠 단건 조회 API 구현 및 구조 리팩토링`

### 📝 작업 내용

* **API 구현:** 메인 콘텐츠 단건 조회 API 추가 (`GET /api/v1/main-contents/{contentId}`)
* **DB/Entity 수정:** `MainPageContent` 엔티티에서 불필요한 `publisher` 연관관계 삭제 및 Flyway 마이그레이션 스크립트(`DROP COLUMN`) 추가
* **리팩토링:** 응답 DTO(`MainPageContentResponse`)를 `class`에서 `record`로 변경하여 불변성 확보
* **문서화:** 전용 에러 코드(`MainContentErrorCode`) 정의 및 Swagger 문서화용 어노테이션(`@MainContentErrorDocs`) 적용

### ✅ 테스트 방법

1. 서버 실행 후 Postman 등을 통해 `GET /api/v2/main-contents/{존재하는ID}` 요청
<img width="924" height="642" alt="image" src="https://github.com/user-attachments/assets/66fb5db1-c044-46a7-a219-1e3d09e601a7" />

3. 플라이웨이 실행 문제없는지도 확인
<img width="1776" height="717" alt="image" src="https://github.com/user-attachments/assets/95872bf7-a38c-4b36-b321-af3b9a15e23d" />

### 참고사항
사진 및 동영상 협의 및 여러 구조에서 프론트에서 의도한대로 html 및 화면이 제대로 동작하는지 확인 필요.
현재는 백엔드에서 확인불가.