### PR TITLE
[feat] 관리자 2차 인증 추가 및 채팅 미리보기 개선

### DIFF
--- a/.github/workflows/dev-cicd.yml
+++ b/.github/workflows/dev-cicd.yml
@@ -24,6 +24,7 @@ jobs:
           test -n "${{ secrets.DB_PASSWORD }}"         || (echo "DB_PASSWORD is empty" && exit 1)
           test -n "${{ secrets.JWT_SECRET }}"          || (echo "JWT_SECRET is empty" && exit 1)
           test -n "${{ secrets.DEV_SUDO_PASSWORD }}"   || (echo "DEV_SUDO_PASSWORD is empty" && exit 1)
+          test -n "${{ secrets.PROD_ENCRYPTION_SECRET }}" || (echo "PROD_ENCRYPTION_SECRET is empty" && exit 1)
           echo "All required secrets are set."
 
   quality-tests:
@@ -209,6 +210,8 @@ jobs:
             GCP_PROJECT_ID=${{ secrets.GCP_PROJECT_ID }}
             GCP_TRANSLATE_API_KEY=${{ secrets.GCP_TRANSLATE_API_KEY }}
             GCP_MAP_API_KEY=${{ secrets.GCP_MAP_API_KEY }}
+            
+            ENCRYPTION_SECRET=${{ secrets.PROD_ENCRYPTION_SECRET }}
             
             NAVER_HOST=${{ secrets.NAVER_HOST }}
             APP_NAME=${{ secrets.APP_NAME }}

--- a/.github/workflows/test-cicd.yml
+++ b/.github/workflows/test-cicd.yml
@@ -24,6 +24,7 @@ jobs:
           test -n "${{ secrets.DB_PASSWORD }}"         || (echo "DB_PASSWORD is empty" && exit 1)
           test -n "${{ secrets.TEST_JWT_SECRET }}"          || (echo "TEST_JWT_SECRET is empty" && exit 1)
           test -n "${{ secrets.DEV_SUDO_PASSWORD }}"   || (echo "DEV_SUDO_PASSWORD is empty" && exit 1)
+          test -n "${{ secrets.TEST_ENCRYPTION_SECRET }}" || (echo "TEST_ENCRYPTION_SECRET is empty" && exit 1)
           echo "All required secrets are set."
 
   quality-tests:
@@ -268,6 +269,8 @@ jobs:
             GCP_PROJECT_ID=${{ secrets.GCP_PROJECT_ID }}
             GCP_TRANSLATE_API_KEY=${{ secrets.GCP_TRANSLATE_API_KEY }}
             GCP_MAP_API_KEY=${{ secrets.GCP_MAP_API_KEY }}
+            
+            ENCRYPTION_SECRET=${{ secrets.TEST_ENCRYPTION_SECRET }}
             
             NAVER_HOST=${{ secrets.NAVER_HOST }}
             APP_NAME=${{ secrets.APP_NAME }}

--- a/build.gradle
+++ b/build.gradle
@@ -111,6 +111,9 @@ dependencies {
     implementation("org.flywaydb:flyway-core")
     implementation("org.flywaydb:flyway-database-postgresql")
 
+    // --- Google Authenticator ---
+    implementation 'com.warrenstrange:googleauth:1.5.0'
+
     implementation 'org.jsoup:jsoup:1.17.2'
     implementation 'org.htmlunit:htmlunit:3.11.0'
     implementation 'org.webjars.npm:cropperjs:1.5.13'

--- a/src/main/java/core/domain/admin/service/AdminAuthService.java
+++ b/src/main/java/core/domain/admin/service/AdminAuthService.java
@@ -1,0 +1,116 @@
+package core.domain.admin.service;
+
+import core.domain.user.dto.AdminLoginStep1Response;
+import core.domain.user.dto.OtpVerificationRequest;
+import core.domain.user.entity.AdminOtp;
+import core.domain.user.entity.User;
+import core.domain.user.repository.AdminOtpRepository;
+import core.domain.user.repository.UserRepository;
+import core.domain.user.service.GoogleOtpService;
+import core.global.dto.AuthResponse;
+import core.global.dto.EmailLoginDto;
+import core.global.dto.UserLoggedInEvent;
+import core.global.enums.Ouathplatform;
+import core.global.enums.Role;
+import core.global.enums.errorcode.AuthErrorCode;
+import core.global.enums.errorcode.UserErrorCode;
+import core.global.exception.BusinessException;
+import core.global.redis.service.RedisService;
+import core.global.security.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AdminAuthService {
+
+    private final UserRepository userRepository;
+    private final AdminOtpRepository adminOtpRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final PasswordEncoder passwordEncoder;
+    private final GoogleOtpService googleOtpService;
+    private final RedisService redisService;
+    private final ApplicationEventPublisher publisher;
+
+    public AdminLoginStep1Response loginStep1(EmailLoginDto req) {
+        User user = userRepository.findByEmail(req.getEmail())
+                .orElseThrow(() -> {
+                    log.warn("[ADMIN LOGIN Step1] 사용자 없음: email={}", req.getEmail());
+                    return new BusinessException(UserErrorCode.AUTHENTICATION_FAILED);
+                });
+
+        if (!Ouathplatform.local.toString().equalsIgnoreCase(user.getProvider())) {
+            log.warn("[ADMIN LOGIN Step1] Provider 불일치: {}", user.getProvider());
+            throw new BusinessException(UserErrorCode.AUTHENTICATION_FAILED);
+        }
+
+        if (!passwordEncoder.matches(req.getPassword(), user.getPassword())) {
+            log.warn("[ADMIN LOGIN Step1] 비밀번호 불일치");
+            throw new BusinessException(UserErrorCode.AUTHENTICATION_FAILED);
+        }
+
+        if (user.getUserRole() != Role.ADMIN) {
+            log.warn("[ADMIN LOGIN Step1] 관리자 권한 없음");
+            throw new BusinessException(AuthErrorCode.AUTHENTICATION_ADMIN_FAILED);
+        }
+
+        Optional<AdminOtp> otpOp = adminOtpRepository.findByUser(user);
+        String qrUrl = null;
+
+        if (otpOp.isEmpty()) {
+            var key = googleOtpService.generateSecretKey();
+            adminOtpRepository.save(AdminOtp.builder().user(user).secretKey(key.getKey()).build());
+            qrUrl = googleOtpService.getGoogleAuthenticatorBarCode(key.getKey(), user.getEmail());
+        }
+
+        String tempToken = jwtTokenProvider.createAccessToken(user.getId(), "PRE_AUTH_ADMIN", user.getEmail());
+
+        return AdminLoginStep1Response.builder()
+                .requiresOtp(true)
+                .tempToken(tempToken)
+                .qrCodeUrl(qrUrl)
+                .build();
+    }
+
+    public AuthResponse loginStep2(OtpVerificationRequest req) {
+        if (!jwtTokenProvider.validateToken(req.getTempToken())) {
+            throw new BusinessException(AuthErrorCode.INVALID_TOKEN);
+        }
+        if (!"PRE_AUTH_ADMIN".equals(jwtTokenProvider.getRoleFromToken(req.getTempToken()))) {
+            throw new BusinessException(AuthErrorCode.INVALID_AUTH_STEP);
+        }
+
+        User user = userRepository.findByEmail(req.getEmail())
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        AdminOtp adminOtp = adminOtpRepository.findByUser(user)
+                .orElseThrow(() -> new BusinessException(AuthErrorCode.AUTHENTICATION_ADMIN_FAILED));
+
+        if (!googleOtpService.verifyCode(adminOtp.getSecretKey(), req.getOtpCode())) {
+            log.warn("[ADMIN LOGIN Step2] OTP 불일치: email={}", user.getEmail());
+            throw new BusinessException(AuthErrorCode.INVALID_OTP);
+        }
+
+        adminOtp.useToken();
+
+        String accessToken = jwtTokenProvider.createAccessToken(user.getId(), Role.ADMIN.name(), user.getEmail());
+        String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+
+        long ttlMs = jwtTokenProvider.getExpiration(refreshToken).getTime() - System.currentTimeMillis();
+        redisService.saveRefreshToken(user.getId(), refreshToken, ttlMs);
+
+        publisher.publishEvent(new UserLoggedInEvent(user.getId().toString(), "email"));
+        log.info("[ADMIN LOGIN Success] 관리자 로그인 완료: id={}", user.getId());
+
+        long accessExpiresIn = jwtTokenProvider.getExpiration(accessToken).getTime() - System.currentTimeMillis();
+        return new AuthResponse("Bearer", accessToken, refreshToken, accessExpiresIn, user.getId(), user.getEmail(), false);
+    }
+}

--- a/src/main/java/core/domain/admin/service/AdminAuthService.java
+++ b/src/main/java/core/domain/admin/service/AdminAuthService.java
@@ -17,6 +17,7 @@ import core.global.enums.errorcode.UserErrorCode;
 import core.global.exception.BusinessException;
 import core.global.redis.service.RedisService;
 import core.global.security.JwtTokenProvider;
+import core.global.service.SmtpMailService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -24,6 +25,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.util.Optional;
 
 @Slf4j
@@ -39,6 +41,10 @@ public class AdminAuthService {
     private final GoogleOtpService googleOtpService;
     private final RedisService redisService;
     private final ApplicationEventPublisher publisher;
+    private final SmtpMailService smtpMailService;
+
+    private static final String OTP_RESET_PREFIX = "admin:otp-reset:";
+    private static final long RESET_CODE_TTL = 5L;
 
     public AdminLoginStep1Response loginStep1(EmailLoginDto req) {
         User user = userRepository.findByEmail(req.getEmail())
@@ -112,5 +118,45 @@ public class AdminAuthService {
 
         long accessExpiresIn = jwtTokenProvider.getExpiration(accessToken).getTime() - System.currentTimeMillis();
         return new AuthResponse("Bearer", accessToken, refreshToken, accessExpiresIn, user.getId(), user.getEmail(), false);
+    }
+
+    public void sendOtpResetCode(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        if (user.getUserRole() != Role.ADMIN) {
+            throw new BusinessException(AuthErrorCode.AUTHENTICATION_ADMIN_FAILED);
+        }
+
+        if (adminOtpRepository.findByUser(user).isEmpty()) {
+            throw new BusinessException(AuthErrorCode.OTP_NOT_REGISTERED);
+        }
+
+        String code = String.valueOf((int)(Math.random() * 900000) + 100000);
+
+        redisService.setDataExpire(OTP_RESET_PREFIX + email, code, Duration.ofMinutes(RESET_CODE_TTL).toMillis());
+
+        smtpMailService.sendAdminOtpResetEmail(email, code, Duration.ofMinutes(RESET_CODE_TTL));
+    }
+
+    public void resetOtp(String email, String code) {
+        String savedCode = redisService.getData(OTP_RESET_PREFIX + email);
+
+        if (savedCode == null) {
+            throw new BusinessException(AuthErrorCode.VERIFY_CODE_EXPIRES);
+        }
+        if (!savedCode.equals(code)) {
+            throw new BusinessException(AuthErrorCode.VERIFY_CODE_NOT_MATCH);
+        }
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        AdminOtp adminOtp = adminOtpRepository.findByUser(user)
+                .orElseThrow(() -> new BusinessException(AuthErrorCode.OTP_NOT_REGISTERED));
+
+        adminOtpRepository.delete(adminOtp);
+        redisService.deleteData(OTP_RESET_PREFIX + email);
+        log.info("[Admin OTP Reset] 관리자 OTP 초기화 완료: email={}", email);
     }
 }

--- a/src/main/java/core/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/core/domain/chat/service/ChatRoomService.java
@@ -423,9 +423,7 @@ public class ChatRoomService {
                 String.valueOf(activeCount) // int -> String 변환
         );
     }
-    private GroupChatMainResponse toGroupChatSearchResponse(ChatRoom chatRoom) {
-        return toGroupChatMainResponse(chatRoom);
-    }
+
 
     class ChatRoomSortData {
         ChatRoom room;
@@ -499,37 +497,51 @@ public class ChatRoomService {
         // 7. 최종 응답 변환 (반복문 사용)
         List<ChatRoomSummaryResponse> responseList = new ArrayList<>();
         for (ChatRoomSortData data : sortList) {
-            // 변환 메서드 호출
-            ChatRoomSummaryResponse summary = createSummaryResponse(data.room, data.lastMessage, userId);
+
+            // [수정] 메시지 미리보기 텍스트 변환 로직 적용
+            String previewContent = getPreviewContent(data.lastMessage);
+            ChatRoomSummaryResponse summary = createSummaryResponse(data.room, data.lastMessage, previewContent, userId);
+
             responseList.add(summary);
         }
-
         return responseList;
     }
+    private String getPreviewContent(ChatMessage message) {
+        if (message == null) {
+            return "";
+        }
 
-    private ChatRoomSummaryResponse createSummaryResponse(ChatRoom room, ChatMessage lastMessage, Long userId) {
-        // [기본 정보 설정]
-        String lastMessageContent = "";
+        switch (message.getMessageType()) {
+            case IMAGE:
+                return "Sent a photo"; // 📷
+            case VIDEO:
+                return "Sent a video"; // 🎥
+            case TEXT:
+            default:
+                return message.getContent();
+        }
+
+    }
+    private ChatRoomSummaryResponse createSummaryResponse(ChatRoom room, ChatMessage lastMessage, String previewContent, Long userId) {
+
+        // [시간 설정]
         Instant lastMessageTime = room.getCreatedAt();
-
         if (lastMessage != null) {
-            lastMessageContent = lastMessage.getContent();
             lastMessageTime = lastMessage.getSentAt();
         }
+        // (내용은 인자로 받은 previewContent를 그대로 사용하므로 별도 로직 불필요)
 
         int unreadCount = countUnreadMessages(room.getId(), userId);
 
-        // [참여자 분석] 반복문 하나로 '활성 인원 카운트'와 '상대방 찾기' 동시 수행
+        // [참여자 분석]
         int activeParticipantCount = 0;
         User opponent = null;
 
         for (ChatParticipant p : room.getParticipants()) {
-            // 1. 활성 상태인 참여자만 카운트 (수정된 부분)
             if (p.getStatus() == ChatParticipantStatus.ACTIVE) {
                 activeParticipantCount++;
             }
-
-            // 2. 1:1 채팅일 경우 상대방 찾기 (내가 아닌 유저)
+            // 1:1 채팅일 경우 상대방 찾기
             if (!room.getIsGroup() && !p.getUser().getId().equals(userId)) {
                 opponent = p.getUser();
             }
@@ -558,11 +570,11 @@ public class ChatRoomService {
         return new ChatRoomSummaryResponse(
                 room.getId(),
                 roomName,
-                lastMessageContent,
+                previewContent, // ✅ 변환된 텍스트 삽입
                 lastMessageTime,
                 roomImageUrl,
                 unreadCount,
-                activeParticipantCount // 수정된 카운트 적용
+                activeParticipantCount
         );
     }
 }

--- a/src/main/java/core/domain/maincontent/repository/search/MainContentSearchRepositoryImpl.java
+++ b/src/main/java/core/domain/maincontent/repository/search/MainContentSearchRepositoryImpl.java
@@ -95,7 +95,7 @@ public class MainContentSearchRepositoryImpl implements MainContentSearchReposit
         String sql = """
                 WITH docs AS (
                   SELECT m.content_id AS doc_id, m.title -- 본문보다 제목에서 키워드 추출이 더 정확함
-                  FROM main_page_content m
+                  FROM main_content m
                   WHERE m.created_at >= now() - interval '14 days' -- 뉴스는 기간을 조금 더 넓게 잡아도 됨
                 ),
                 tokens AS (
@@ -179,7 +179,7 @@ public class MainContentSearchRepositoryImpl implements MainContentSearchReposit
                 FROM (
                     SELECT m.content_id AS doc_id, 
                            btrim((t.token_json::jsonb ->> 'value')) AS term
-                    FROM main_page_content m
+                    FROM main_content m
                     CROSS JOIN LATERAL unnest(
                         pgroonga_tokenize(m.title, 'tokenizer', 'TokenDelimit')
                     ) AS t(token_json)
@@ -204,7 +204,7 @@ public class MainContentSearchRepositoryImpl implements MainContentSearchReposit
     public boolean existsInContents(String keyword) {
         String sql = """
             SELECT EXISTS (
-                SELECT 1 FROM main_page_content 
+                SELECT 1 FROM main_content 
                 WHERE title &@ :keyword OR html_content &@ :keyword -- 실제 컬럼명으로 수정
                 LIMIT 1
             )

--- a/src/main/java/core/domain/user/controller/LoginRegisterController.java
+++ b/src/main/java/core/domain/user/controller/LoginRegisterController.java
@@ -121,6 +121,20 @@ public class LoginRegisterController {
         return ResponseEntity.ok(ApiResponse.success("관리자 로그인 성공"));
     }
 
+    @PostMapping("/admin/otp/reset-request")
+    @Operation(summary = "관리자 OTP 초기화 메일 발송")
+    public ResponseEntity<ApiResponse<String>> requestOtpReset(@RequestBody EmailRequest req) {
+        adminAuthService.sendOtpResetCode(req.getEmail());
+        return ResponseEntity.ok(ApiResponse.success("인증 코드가 메일로 발송되었습니다."));
+    }
+
+    @PostMapping("/admin/otp/reset-confirm")
+    @Operation(summary = "관리자 OTP 초기화 수행 (코드 검증)")
+    public ResponseEntity<ApiResponse<String>> confirmOtpReset(@RequestBody EmailVerificationRequest req) {
+        adminAuthService.resetOtp(req.getEmail(), req.getVerificationCode());
+        return ResponseEntity.ok(ApiResponse.success("OTP가 초기화되었습니다. 다시 로그인하여 재설정하세요."));
+    }
+
     @PostMapping("/refresh")
     @AuthErrorDocs({AuthErrorCode.INVALID_REFRESH_TOKEN,AuthErrorCode.INVALID_TOKEN })
     @Operation(summary = "토큰 재발급 API", description = "리프레시 토큰으로 새로운 액세스 토큰과 리프레시 토큰을 발급합니다.")

--- a/src/main/java/core/domain/user/controller/LoginRegisterController.java
+++ b/src/main/java/core/domain/user/controller/LoginRegisterController.java
@@ -1,9 +1,7 @@
 package core.domain.user.controller;
 
-import core.domain.chat.dto.ChatUserProfileResponse;
+import core.domain.admin.service.AdminAuthService;
 import core.domain.user.dto.*;
-import core.domain.user.entity.User;
-import core.domain.user.repository.UserRepository;
 import core.domain.user.service.UserService;
 import core.global.apple.dto.AppleLoginByCodeRequest;
 import core.global.apple.dto.WithdrawIsApple;
@@ -18,9 +16,7 @@ import core.global.enums.errorcode.AuthErrorCode;
 import core.global.enums.errorcode.GlobalErrorCode;
 import core.global.enums.errorcode.ImageErrorCode;
 import core.global.enums.errorcode.UserErrorCode;
-import core.global.exception.BusinessException;
 import core.global.metrics.FeatureUsageMetrics;
-import core.global.redis.service.RedisService;
 import core.global.security.JwtTokenProvider;
 import core.global.service.GeoService;
 import core.global.service.GoogleAuthService;
@@ -39,17 +35,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.i18n.LocaleContextHolder;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Date;
 import java.util.List;
 import java.util.Locale;
-import java.util.Optional;
 
 @Tag(name = "User", description = "사용자 회원가입,로그인 관련 API")
 @RestController
@@ -67,6 +59,7 @@ public class LoginRegisterController {
     private final CookieUtil cookieUtil;
     private final GeoService geoService;
     private final JwtTokenProvider jwtTokenProvider;
+    private final AdminAuthService adminAuthService;
 
     @PostMapping("/doLogin")
     @Operation(summary = "일반 로그인")
@@ -105,6 +98,27 @@ public class LoginRegisterController {
         LoginResponseDto responseDto = appleAuthService.login(req);
         publisher.publishEvent(new UserLoggedInEvent(responseDto.userId().toString(), "apple"));
         return ResponseEntity.ok(ApiResponse.success(responseDto));
+    }
+
+    @PostMapping("/admin/login")
+    @Operation(summary = "관리자 1차 로그인 (ID/PW)")
+    public ResponseEntity<ApiResponse<AdminLoginStep1Response>> adminLoginStep1(
+            @Valid @RequestBody EmailLoginDto req) {
+        return ResponseEntity.ok(ApiResponse.success(adminAuthService.loginStep1(req)));
+    }
+
+    @PostMapping("/admin/otp-verify")
+    @Operation(summary = "관리자 2차 로그인 (OTP)")
+    public ResponseEntity<ApiResponse<String>> adminLoginStep2(
+            @RequestBody OtpVerificationRequest req,
+            HttpServletResponse httpResponse) {
+
+        AuthResponse authResponse = adminAuthService.loginStep2(req);
+
+        long maxAgeInSeconds = authResponse.expiresInMillis() / 1000;
+        cookieUtil.createTokenCookie(httpResponse, "accessToken", authResponse.accessToken(), maxAgeInSeconds);
+
+        return ResponseEntity.ok(ApiResponse.success("관리자 로그인 성공"));
     }
 
     @PostMapping("/refresh")

--- a/src/main/java/core/domain/user/controller/LoginRegisterController.java
+++ b/src/main/java/core/domain/user/controller/LoginRegisterController.java
@@ -160,38 +160,6 @@ public class LoginRegisterController {
         return ResponseEntity.ok(ApiResponse.success(result));
     }
 
-
-    @Operation(summary = "관리자 웹페이지 전용 로그인",
-            description = "관리자 계정(ADMIN)인지 확인하고, HttpOnly 쿠키에 accessToken을 발급합니다.")
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "관리자 로그인 성공"),
-    })
-    @PostMapping("/admin/login")
-    @UserErrorDocs({UserErrorCode.AUTHENTICATION_FAILED,})
-    @AuthErrorDocs({AuthErrorCode.AUTHENTICATION_ADMIN_FAILED})
-    public ResponseEntity<ApiResponse<String>> adminWebLogin(
-            @Valid @RequestBody EmailLoginDto req,
-            HttpServletResponse httpResponse
-    ) {
-        try {
-            AuthResponse authResponse = userService.adminLogin(req);
-
-            long maxAgeInSeconds = authResponse.expiresInMillis() / 1000;
-            cookieUtil.createTokenCookie(
-                    httpResponse,
-                    "accessToken",
-                    authResponse.accessToken(),
-                    maxAgeInSeconds
-            );
-
-            return ResponseEntity.ok(ApiResponse.success("관리자 로그인 성공"));
-
-        } catch (BusinessException e) {
-            return ResponseEntity.status(e.getStatus())
-                    .body(ApiResponse.fail(e.getMessage()));
-        }
-    }
-
     @PostMapping("/email/check")
     @Operation(summary = "이메일 가입 중복 여부 확인")
     public ResponseEntity<ApiResponse<EmailCheckResponse>> checkRepeat(@RequestBody EmailCheckRequest request) {

--- a/src/main/java/core/domain/user/dto/AdminLoginStep1Response.java
+++ b/src/main/java/core/domain/user/dto/AdminLoginStep1Response.java
@@ -1,0 +1,12 @@
+package core.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AdminLoginStep1Response {
+    private boolean requiresOtp;
+    private String tempToken;
+    private String qrCodeUrl;
+}

--- a/src/main/java/core/domain/user/dto/OtpVerificationRequest.java
+++ b/src/main/java/core/domain/user/dto/OtpVerificationRequest.java
@@ -1,0 +1,12 @@
+package core.domain.user.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class OtpVerificationRequest {
+    private String email;
+    private String otpCode;
+    private String tempToken;
+}

--- a/src/main/java/core/domain/user/entity/AdminOtp.java
+++ b/src/main/java/core/domain/user/entity/AdminOtp.java
@@ -1,0 +1,45 @@
+package core.domain.user.entity;
+
+import core.global.config.StringCryptoConverter;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "admin_otp")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AdminOtp {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @Convert(converter = StringCryptoConverter.class)
+    @Column(name = "secret_key", nullable = false)
+    private String secretKey;
+
+    @Column(name = "last_used_at")
+    private Instant lastUsedAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Builder
+    public AdminOtp(User user, String secretKey) {
+        this.user = user;
+        this.secretKey = secretKey;
+        this.createdAt = Instant.now();
+    }
+
+    public void useToken() {
+        this.lastUsedAt = Instant.now();
+    }
+}

--- a/src/main/java/core/domain/user/repository/AdminOtpRepository.java
+++ b/src/main/java/core/domain/user/repository/AdminOtpRepository.java
@@ -1,0 +1,11 @@
+package core.domain.user.repository;
+
+import core.domain.user.entity.AdminOtp;
+import core.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AdminOtpRepository extends JpaRepository<AdminOtp, Long> {
+    Optional<AdminOtp> findByUser(User user);
+}

--- a/src/main/java/core/domain/user/service/GoogleOtpService.java
+++ b/src/main/java/core/domain/user/service/GoogleOtpService.java
@@ -1,0 +1,45 @@
+package core.domain.user.service;
+
+import com.warrenstrange.googleauth.GoogleAuthenticator;
+import com.warrenstrange.googleauth.GoogleAuthenticatorKey;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GoogleOtpService {
+
+    private final GoogleAuthenticator gAuth = new GoogleAuthenticator();
+
+    @Value("${otp.issuer:Kori-Admin}")
+    private String issuer;
+
+    @Value("${otp.magic-code-enabled:false}")
+    private boolean magicCodeEnabled;
+
+    public GoogleAuthenticatorKey generateSecretKey() {
+        return gAuth.createCredentials();
+    }
+
+    public String getGoogleAuthenticatorBarCode(String secretKey, String account) {
+        return "otpauth://totp/"
+                + issuer + ":" + account
+                + "?secret=" + secretKey
+                + "&issuer=" + issuer;
+    }
+
+    public boolean verifyCode(String secretKey, String code) {
+        if (magicCodeEnabled && "000000".equals(code)) {
+            log.info(">>>> [OTP] 개발용 만능키(000000) 통과. Issuer: {}", issuer);
+            return true;
+        }
+        try {
+            return gAuth.authorize(secretKey, Integer.parseInt(code));
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/core/domain/user/service/UserService.java
+++ b/src/main/java/core/domain/user/service/UserService.java
@@ -485,47 +485,6 @@ public class UserService {
         return new AuthResponse("Bearer", access, refresh, expiresInMs, u.getId(), u.getEmail(), u.isNewUser());
     }
 
-    @Transactional
-    public AuthResponse adminLogin(EmailLoginDto req) {
-
-        String email = normalizeEmail(req.getEmail());
-
-        User u = userRepository.findByEmail(email)
-                .orElseThrow(() -> {
-                    log.warn("[ADMIN LOGIN] 사용자 없음: email={}", email);
-                    return new BusinessException(UserErrorCode.AUTHENTICATION_FAILED);
-                });
-
-        log.debug("[ADMIN LOGIN] 사용자 조회 성공: id={}, provider={}", u.getId(), u.getProvider());
-
-        if (!Ouathplatform.local.toString().equalsIgnoreCase(nullToEmpty(u.getProvider()))) {
-            log.warn("[ADMIN LOGIN] provider 불일치: provider={}", u.getProvider());
-            throw new BusinessException(UserErrorCode.AUTHENTICATION_FAILED);
-        }
-
-        if (u.getPassword() == null || !passwordEncoder.matches(req.getPassword(), u.getPassword())) {
-            log.warn("[ADMIN LOGIN] 비밀번호 불일치: email={}", email);
-            throw new BusinessException(UserErrorCode.AUTHENTICATION_FAILED);
-        }
-
-        if (u.getUserRole() != Role.ADMIN) {
-            log.warn("[ADMIN LOGIN] 관리자 계정이 아님: id={}, role={}", u.getId(), u.getUserRole());
-            throw new BusinessException(AuthErrorCode.AUTHENTICATION_ADMIN_FAILED);
-        }
-
-        String access = jwtTokenProvider.createAccessToken(u.getId(), u.getUserRole().name(), u.getEmail());
-        String refresh = jwtTokenProvider.createRefreshToken(u.getId());
-        long expiresInMs = jwtTokenProvider.getExpiration(access).getTime() - System.currentTimeMillis();
-        Date refreshExpiration = jwtTokenProvider.getExpiration(refresh);
-        long refreshExpirationMillis = refreshExpiration.getTime() - System.currentTimeMillis();
-        redisService.saveRefreshToken(u.getId(), refresh, refreshExpirationMillis);
-
-        log.info("[ADMIN LOGIN] 관리자 로그인 성공: id={}, email={}", u.getId(), u.getEmail());
-        publisher.publishEvent(new UserLoggedInEvent(u.getId().toString(), "email"));
-
-        return new AuthResponse("Bearer", access, refresh, expiresInMs, u.getId(), u.getEmail(), u.isNewUser());
-    }
-
     /**
      * 이메일 보내주는 로직
      */

--- a/src/main/java/core/global/config/StringCryptoConverter.java
+++ b/src/main/java/core/global/config/StringCryptoConverter.java
@@ -1,0 +1,49 @@
+package core.global.config;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.SecretKeySpec;
+import java.util.Base64;
+
+@Component
+@Converter
+public class StringCryptoConverter implements AttributeConverter<String, String> {
+
+    private static String KEY;
+    private static final String ALGORITHM = "AES";
+
+    @Value("${encryption.secret}")
+    public void setKey(String key) {
+        KEY = key;
+    }
+
+    @Override
+    public String convertToDatabaseColumn(String attribute) {
+        if (attribute == null) return null;
+        try {
+            SecretKeySpec keySpec = new SecretKeySpec(KEY.getBytes(), ALGORITHM);
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.ENCRYPT_MODE, keySpec);
+            return Base64.getEncoder().encodeToString(cipher.doFinal(attribute.getBytes()));
+        } catch (Exception e) {
+            throw new RuntimeException("암호화 실패", e);
+        }
+    }
+
+    @Override
+    public String convertToEntityAttribute(String dbData) {
+        if (dbData == null) return null;
+        try {
+            SecretKeySpec keySpec = new SecretKeySpec(KEY.getBytes(), ALGORITHM);
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.DECRYPT_MODE, keySpec);
+            return new String(cipher.doFinal(Base64.getDecoder().decode(dbData)));
+        } catch (Exception e) {
+            throw new RuntimeException("복호화 실패", e);
+        }
+    }
+}

--- a/src/main/java/core/global/enums/errorcode/AuthErrorCode.java
+++ b/src/main/java/core/global/enums/errorcode/AuthErrorCode.java
@@ -39,6 +39,10 @@ public enum AuthErrorCode implements AppError {
     VERIFY_CODE_NOT_MATCH(HttpStatus.CONFLICT, "인증 코드가 일치하지 않습니다."),
     VERIFY_CODE_NEED_RESEND(HttpStatus.BAD_REQUEST, "인증 코드를 다시 요청해야 합니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 유효하지 않거나 만료되었습니다."),
+
+    INVALID_AUTH_STEP(HttpStatus.UNAUTHORIZED, "인증 단계가 올바르지 않습니다. (1차 인증 토큰 확인 필요)"),
+    INVALID_OTP(HttpStatus.UNAUTHORIZED, "OTP 코드가 일치하지 않습니다."),
+
     // [추가 권장] 토큰 자체가 형식이 잘못되었거나 만료된 경우
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다.");
 

--- a/src/main/java/core/global/enums/errorcode/AuthErrorCode.java
+++ b/src/main/java/core/global/enums/errorcode/AuthErrorCode.java
@@ -42,6 +42,7 @@ public enum AuthErrorCode implements AppError {
 
     INVALID_AUTH_STEP(HttpStatus.UNAUTHORIZED, "인증 단계가 올바르지 않습니다. (1차 인증 토큰 확인 필요)"),
     INVALID_OTP(HttpStatus.UNAUTHORIZED, "OTP 코드가 일치하지 않습니다."),
+    OTP_NOT_REGISTERED(HttpStatus.BAD_REQUEST, "등록된 OTP 정보가 없습니다. 초기화할 필요 없이 바로 로그인하시면 됩니다."),
 
     // [추가 권장] 토큰 자체가 형식이 잘못되었거나 만료된 경우
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다.");

--- a/src/main/java/core/global/redis/service/RedisService.java
+++ b/src/main/java/core/global/redis/service/RedisService.java
@@ -82,4 +82,28 @@ public class RedisService {
     private String getBlacklistKey(String token) {
         return blacklistPrefix + token;
     }
+
+    /**
+     * 일반 데이터 저장 (만료 시간 포함)
+     * @param key 저장할 키 (예: admin:otp-reset:email)
+     * @param value 저장할 값 (예: 인증코드)
+     * @param durationMillis 만료 시간(밀리초)
+     */
+    public void setDataExpire(String key, String value, long durationMillis) {
+        redisTemplate.opsForValue().set(key, value, durationMillis, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * 일반 데이터 조회
+     */
+    public String getData(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    /**
+     * 일반 데이터 삭제
+     */
+    public void deleteData(String key) {
+        redisTemplate.delete(key);
+    }
 }

--- a/src/main/java/core/global/security/PermitAllPaths.java
+++ b/src/main/java/core/global/security/PermitAllPaths.java
@@ -26,6 +26,7 @@ public final class PermitAllPaths {
             "/swagger-resources/**",
             "/admin/login",
             "/api/v1/member/admin/login",
+            "/api/v1/member/admin/otp-verify",
             "/admin/test/send-message",
             "/api/v1/app/**",
             "/internal/smoke"

--- a/src/main/java/core/global/security/PermitAllPaths.java
+++ b/src/main/java/core/global/security/PermitAllPaths.java
@@ -27,6 +27,8 @@ public final class PermitAllPaths {
             "/admin/login",
             "/api/v1/member/admin/login",
             "/api/v1/member/admin/otp-verify",
+            "/api/v1/member/admin/otp/reset-request",
+            "/api/v1/member/admin/otp/reset-confirm",
             "/admin/test/send-message",
             "/api/v1/app/**",
             "/internal/smoke"

--- a/src/main/java/core/global/service/SmtpMailService.java
+++ b/src/main/java/core/global/service/SmtpMailService.java
@@ -1,24 +1,16 @@
 package core.global.service;
 
 import core.global.config.AsyncMailDispatcher;
-import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.MessageSource;
-import org.springframework.context.i18n.LocaleContextHolder;
-import org.springframework.mail.MailException;
-import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
 
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Locale;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadLocalRandom;
 
 @Slf4j
@@ -27,7 +19,6 @@ import java.util.concurrent.ThreadLocalRandom;
 public class SmtpMailService {
 
     private final MessageSource messageSource;
-    private final JavaMailSender mailSender;
     private final TemplateEngine templateEngine; // ✅ 타임리프 템플릿 엔진 주입
     private final AsyncMailDispatcher asyncMailDispatcher;
 
@@ -36,6 +27,23 @@ public class SmtpMailService {
 
     @Value("${app.mail.brand}")
     private String defaultBrand; // 번들에 brand.name 없을 때 기본값
+
+    public void sendAdminOtpResetEmail(String toEmail, String code, Duration ttl) {
+        String subject = "[Kori] 관리자 OTP 초기화 인증번호입니다.";
+
+        Locale locale = Locale.KOREA;
+
+        Context ctx = new Context(locale);
+        ctx.setVariable("brand", defaultBrand);
+        ctx.setVariable("code", code);
+        ctx.setVariable("ttlMinutes", ttl.toMinutes());
+
+        String html = templateEngine.process("email/verification", ctx);
+
+        asyncMailDispatcher.sendHtmlAsync(from, toEmail, subject, html);
+
+        log.info("[Admin OTP] 초기화 메일 발송 완료: {} (코드: {})", toEmail, code);
+    }
 
     public String sendVerificationEmail(String toEmail, Duration ttl, Locale locale) {
         // 1) 코드 생성

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -383,3 +383,6 @@ openai:
 otp:
   issuer: "Kori-Admin"
   magic-code-enabled: false
+
+encryption:
+  secret: ${ENCRYPTION_SECRET}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -379,3 +379,7 @@ smoke:
 
 openai:
   api-key: ${OPEN_AI_KEY}
+
+otp:
+  issuer: "Kori-Admin"
+  magic-code-enabled: false

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -176,3 +176,6 @@ openai:
 otp:
   issuer: "Kori-Admin (Local)"
   magic-code-enabled: true
+
+encryption:
+  secret: ${ENCRYPTION_SECRET}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -172,3 +172,7 @@ sightengine:
 
 openai:
   api-key: ${OPEN_AI_KEY}
+
+otp:
+  issuer: "Kori-Admin (Local)"
+  magic-code-enabled: true

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -379,3 +379,7 @@ smoke:
 
 openai:
   api-key: ${OPEN_AI_KEY}
+
+otp:
+  issuer: "Kori-Admin (Test)"
+  magic-code-enabled: false

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -383,3 +383,6 @@ openai:
 otp:
   issuer: "Kori-Admin (Test)"
   magic-code-enabled: false
+
+encryption:
+  secret: ${ENCRYPTION_SECRET}

--- a/src/main/resources/db/migration/V202601100040__create_admin_otp.sql
+++ b/src/main/resources/db/migration/V202601100040__create_admin_otp.sql
@@ -1,0 +1,9 @@
+CREATE TABLE admin_otp (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    secret_key VARCHAR(255) NOT NULL,
+    last_used_at TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_admin_otp_user FOREIGN KEY (user_id) REFERENCES users(user_id),
+    CONSTRAINT uk_admin_otp_user UNIQUE (user_id)
+);

--- a/src/main/resources/templates/admin/admin-login.html
+++ b/src/main/resources/templates/admin/admin-login.html
@@ -2,65 +2,186 @@
 <html lang="ko">
 <head>
     <meta charset="UTF-8">
-    <title>관리자 로그인</title>
+    <title>Kori 관리자 로그인</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
     <style>
-        body { font-family: sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; background-color: #f4f6f9; }
-        .login-container { background-color: white; padding: 40px; border-radius: 10px; box-shadow: 0 4px 12px rgba(0,0,0,0.1); text-align: center; }
-        h1 { color: #333; margin-bottom: 30px; }
+        body { font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; background-color: #f4f6f9; margin: 0; }
+        .login-container { background-color: white; padding: 40px; border-radius: 12px; box-shadow: 0 4px 20px rgba(0,0,0,0.1); text-align: center; width: 380px; }
+        h1 { color: #333; margin-bottom: 10px; font-size: 24px; }
+        .subtitle { color: #666; font-size: 14px; margin-bottom: 30px; }
+
         .form-group { margin-bottom: 20px; text-align: left; }
-        .form-group label { display: block; margin-bottom: 8px; font-weight: bold; }
-        .form-group input { width: 300px; padding: 12px; border: 1px solid #ddd; border-radius: 5px; font-size: 16px; }
-        .btn-login { width: 100%; padding: 12px; background-color: #007bff; color: white; border: none; border-radius: 5px; font-size: 16px; cursor: pointer; transition: background-color 0.2s; }
+        .form-group label { display: block; margin-bottom: 8px; font-weight: 600; font-size: 14px; color: #555; }
+        .form-group input { width: 100%; padding: 12px; border: 1px solid #ddd; border-radius: 6px; font-size: 15px; box-sizing: border-box; transition: border-color 0.2s; }
+        .form-group input:focus { border-color: #007bff; outline: none; }
+
+        .btn-login { width: 100%; padding: 12px; background-color: #007bff; color: white; border: none; border-radius: 6px; font-size: 16px; font-weight: 600; cursor: pointer; transition: background-color 0.2s; margin-top: 10px; }
         .btn-login:hover { background-color: #0056b3; }
-        #error-message { color: red; margin-top: 15px; display: none; }
+
+        #error-message { color: #e74c3c; margin-top: 20px; display: none; font-size: 14px; background-color: #fdecea; padding: 10px; border-radius: 4px; }
+
+        /* 2단계 인증 관련 스타일 */
+        #step-2-container { display: none; }
+        #qr-code-area { display: flex; flex-direction: column; align-items: center; margin-bottom: 25px; padding: 15px; background-color: #f8f9fa; border-radius: 8px; border: 1px dashed #ccc; }
+        #qrcode { margin: 15px 0; }
+        .info-text { font-size: 13px; color: #666; margin-bottom: 5px; line-height: 1.5; }
+        .otp-input { text-align: center; letter-spacing: 5px; font-size: 20px !important; font-family: monospace; }
     </style>
 </head>
 <body>
 
 <div class="login-container">
-    <h1>관리자 페이지 로그인</h1>
-    <form id="loginForm">
-        <div class="form-group">
-            <label for="email">이메일</label>
-            <input type="email" id="email" name="email" required>
+    <h1>관리자 로그인</h1>
+    <p class="subtitle">안전한 서비스 관리를 위해 로그인해주세요.</p>
+
+    <div id="step-1-container">
+        <form id="loginFormStep1">
+            <div class="form-group">
+                <label for="email">이메일</label>
+                <input type="email" id="email" name="email" required placeholder="admin@example.com">
+            </div>
+            <div class="form-group">
+                <label for="password">비밀번호</label>
+                <input type="password" id="password" name="password" required placeholder="비밀번호 입력">
+            </div>
+            <button type="submit" class="btn-login">다음 (2차 인증)</button>
+        </form>
+    </div>
+
+    <div id="step-2-container">
+        <div id="qr-code-area" style="display: none;">
+            <p class="info-text"><strong>OTP 초기 설정</strong><br>Google Authenticator 앱으로<br>아래 QR 코드를 스캔하세요.</p>
+            <div id="qrcode"></div>
         </div>
-        <div class="form-group">
-            <label for="password">비밀번호</label>
-            <input type="password" id="password" name="password" required>
-        </div>
-        <button type="submit" class="btn-login">로그인</button>
-        <p id="error-message"></p>
-    </form>
+
+        <form id="loginFormStep2">
+            <div class="form-group">
+                <label for="otpCode">OTP 인증번호</label>
+                <input type="text" id="otpCode" name="otpCode" class="otp-input" maxlength="6" pattern="\d*" required placeholder="000000" autocomplete="off">
+            </div>
+            <p class="info-text">Google Authenticator 앱에 표시된<br>6자리 숫자를 입력하세요.</p>
+            <button type="submit" class="btn-login">인증 확인</button>
+        </form>
+    </div>
+
+    <p id="error-message"></p>
 </div>
 
 <script>
-    document.getElementById('loginForm').addEventListener('submit', async function(event) {
+    // 상태 관리를 위한 변수
+    let tempToken = null; // 1차 인증 후 받을 임시 토큰
+    let userEmail = null;
+
+    const errorMessageEl = document.getElementById('error-message');
+    const step1Container = document.getElementById('step-1-container');
+    const step2Container = document.getElementById('step-2-container');
+    const qrCodeArea = document.getElementById('qr-code-area');
+
+    // [Step 1] ID/PW 제출 처리
+    document.getElementById('loginFormStep1').addEventListener('submit', async function(event) {
         event.preventDefault();
-        const email = document.getElementById('email').value;
+        userEmail = document.getElementById('email').value;
         const password = document.getElementById('password').value;
-        const errorMessageEl = document.getElementById('error-message');
-        errorMessageEl.style.display = 'none';
+
+        hideError();
 
         try {
+            // 1. 백엔드 1차 로그인 API 호출
             const response = await fetch('/api/v1/member/admin/login', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ email: email, password: password })
+                body: JSON.stringify({ email: userEmail, password: password })
             });
 
             const data = await response.json();
 
             if (!response.ok) {
-                throw new Error(data.message || '로그인에 실패했습니다.');
+                // ApiResponse.fail(message) 형태일 경우 data.message 사용
+                throw new Error(data.message || '로그인 정보가 올바르지 않습니다.');
             }
 
+            // 성공 시 ApiResponse.success(data) 구조에서 데이터 추출
+            const result = data.data;
+
+            // 2. 임시 토큰 저장 (2단계에서 사용)
+            tempToken = result.tempToken;
+
+            // 3. 화면 전환 (1단계 숨김 -> 2단계 표시)
+            step1Container.style.display = 'none';
+            step2Container.style.display = 'block';
+
+            // 4. 최초 등록자(QR URL이 있는 경우) 처리
+            if (result.qrCodeUrl) {
+                qrCodeArea.style.display = 'flex';
+                // qrcode.js 라이브러리를 사용해 QR 이미지 생성
+                // (기존 내용은 지우고 새로 생성)
+                document.getElementById("qrcode").innerHTML = "";
+                new QRCode(document.getElementById("qrcode"), {
+                    text: result.qrCodeUrl,
+                    width: 128,
+                    height: 128,
+                    colorDark : "#000000",
+                    colorLight : "#ffffff",
+                    correctLevel : QRCode.CorrectLevel.H
+                });
+            }
+
+            // OTP 입력창에 포커스 이동
+            document.getElementById('otpCode').focus();
+
+        } catch (error) {
+            showError(error.message);
+        }
+    });
+
+    // [Step 2] OTP 제출 처리
+    document.getElementById('loginFormStep2').addEventListener('submit', async function(event) {
+        event.preventDefault();
+        const otpCode = document.getElementById('otpCode').value;
+
+        hideError();
+
+        if (!tempToken) {
+            showError("인증 세션이 만료되었습니다. 처음부터 다시 시도해주세요.");
+            setTimeout(() => window.location.reload(), 2000);
+            return;
+        }
+
+        try {
+            // 1. 백엔드 2차 인증(OTP) API 호출
+            const response = await fetch('/api/v1/member/admin/otp-verify', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    email: userEmail,
+                    otpCode: otpCode,
+                    tempToken: tempToken
+                })
+            });
+
+            const data = await response.json();
+
+            if (!response.ok) {
+                throw new Error(data.message || 'OTP 코드가 일치하지 않습니다.');
+            }
+
+            // 2. 인증 성공! 관리자 메인 페이지로 이동
+            // (백엔드에서 HttpOnly 쿠키로 AccessToken을 설정해 줌)
             window.location.href = '/admin/users/home';
 
         } catch (error) {
-            errorMessageEl.textContent = error.message;
-            errorMessageEl.style.display = 'block';
+            showError(error.message);
         }
     });
+
+    function showError(msg) {
+        errorMessageEl.textContent = msg;
+        errorMessageEl.style.display = 'block';
+    }
+
+    function hideError() {
+        errorMessageEl.style.display = 'none';
+    }
 </script>
 </body>
 </html>

--- a/src/main/resources/templates/admin/admin-login.html
+++ b/src/main/resources/templates/admin/admin-login.html
@@ -20,19 +20,22 @@
 
         #error-message { color: #e74c3c; margin-top: 20px; display: none; font-size: 14px; background-color: #fdecea; padding: 10px; border-radius: 4px; }
 
-        /* 2단계 인증 관련 스타일 */
-        #step-2-container { display: none; }
+        #step-2-container, #step-3-container { display: none; }
         #qr-code-area { display: flex; flex-direction: column; align-items: center; margin-bottom: 25px; padding: 15px; background-color: #f8f9fa; border-radius: 8px; border: 1px dashed #ccc; }
         #qrcode { margin: 15px 0; }
         .info-text { font-size: 13px; color: #666; margin-bottom: 5px; line-height: 1.5; }
         .otp-input { text-align: center; letter-spacing: 5px; font-size: 20px !important; font-family: monospace; }
+
+        .link-area { margin-top: 20px; font-size: 13px; }
+        .link-btn { color: #666; text-decoration: underline; cursor: pointer; background: none; border: none; }
+        .link-btn:hover { color: #007bff; }
     </style>
 </head>
 <body>
 
 <div class="login-container">
     <h1>관리자 로그인</h1>
-    <p class="subtitle">안전한 서비스 관리를 위해 로그인해주세요.</p>
+    <p class="subtitle" id="page-subtitle">안전한 서비스 관리를 위해 로그인해주세요.</p>
 
     <div id="step-1-container">
         <form id="loginFormStep1">
@@ -62,22 +65,49 @@
             <p class="info-text">Google Authenticator 앱에 표시된<br>6자리 숫자를 입력하세요.</p>
             <button type="submit" class="btn-login">인증 확인</button>
         </form>
+
+        <div class="link-area">
+            <button type="button" class="link-btn" onclick="showResetMode()">OTP를 분실하셨나요?</button>
+        </div>
+    </div>
+
+    <div id="step-3-container">
+        <p class="info-text">가입된 이메일로 초기화 코드를 전송합니다.</p>
+
+        <div id="reset-request-area">
+            <div class="form-group">
+                <label for="resetEmail">관리자 이메일</label>
+                <input type="email" id="resetEmail" required disabled>
+            </div>
+            <button type="button" class="btn-login" onclick="requestResetCode()">인증코드 전송</button>
+        </div>
+
+        <div id="reset-confirm-area" style="display: none;">
+            <div class="form-group">
+                <label for="resetCode">이메일 인증코드</label>
+                <input type="text" id="resetCode" class="otp-input" maxlength="6" placeholder="123456">
+            </div>
+            <button type="button" class="btn-login" onclick="confirmResetCode()">초기화 하기</button>
+        </div>
+
+        <div class="link-area">
+            <button type="button" class="link-btn" onclick="location.reload()">로그인으로 돌아가기</button>
+        </div>
     </div>
 
     <p id="error-message"></p>
 </div>
 
 <script>
-    // 상태 관리를 위한 변수
-    let tempToken = null; // 1차 인증 후 받을 임시 토큰
+    let tempToken = null;
     let userEmail = null;
 
     const errorMessageEl = document.getElementById('error-message');
     const step1Container = document.getElementById('step-1-container');
     const step2Container = document.getElementById('step-2-container');
+    const step3Container = document.getElementById('step-3-container');
     const qrCodeArea = document.getElementById('qr-code-area');
 
-    // [Step 1] ID/PW 제출 처리
     document.getElementById('loginFormStep1').addEventListener('submit', async function(event) {
         event.preventDefault();
         userEmail = document.getElementById('email').value;
@@ -86,7 +116,6 @@
         hideError();
 
         try {
-            // 1. 백엔드 1차 로그인 API 호출
             const response = await fetch('/api/v1/member/admin/login', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
@@ -96,25 +125,17 @@
             const data = await response.json();
 
             if (!response.ok) {
-                // ApiResponse.fail(message) 형태일 경우 data.message 사용
                 throw new Error(data.message || '로그인 정보가 올바르지 않습니다.');
             }
 
-            // 성공 시 ApiResponse.success(data) 구조에서 데이터 추출
             const result = data.data;
-
-            // 2. 임시 토큰 저장 (2단계에서 사용)
             tempToken = result.tempToken;
 
-            // 3. 화면 전환 (1단계 숨김 -> 2단계 표시)
             step1Container.style.display = 'none';
             step2Container.style.display = 'block';
 
-            // 4. 최초 등록자(QR URL이 있는 경우) 처리
             if (result.qrCodeUrl) {
                 qrCodeArea.style.display = 'flex';
-                // qrcode.js 라이브러리를 사용해 QR 이미지 생성
-                // (기존 내용은 지우고 새로 생성)
                 document.getElementById("qrcode").innerHTML = "";
                 new QRCode(document.getElementById("qrcode"), {
                     text: result.qrCodeUrl,
@@ -126,7 +147,6 @@
                 });
             }
 
-            // OTP 입력창에 포커스 이동
             document.getElementById('otpCode').focus();
 
         } catch (error) {
@@ -134,7 +154,6 @@
         }
     });
 
-    // [Step 2] OTP 제출 처리
     document.getElementById('loginFormStep2').addEventListener('submit', async function(event) {
         event.preventDefault();
         const otpCode = document.getElementById('otpCode').value;
@@ -148,7 +167,6 @@
         }
 
         try {
-            // 1. 백엔드 2차 인증(OTP) API 호출
             const response = await fetch('/api/v1/member/admin/otp-verify', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
@@ -165,14 +183,59 @@
                 throw new Error(data.message || 'OTP 코드가 일치하지 않습니다.');
             }
 
-            // 2. 인증 성공! 관리자 메인 페이지로 이동
-            // (백엔드에서 HttpOnly 쿠키로 AccessToken을 설정해 줌)
             window.location.href = '/admin/users/home';
 
         } catch (error) {
             showError(error.message);
         }
     });
+
+    function showResetMode() {
+        step2Container.style.display = 'none';
+        step3Container.style.display = 'block';
+        document.getElementById('resetEmail').value = userEmail;
+        document.getElementById('page-subtitle').textContent = "OTP 정보를 초기화합니다.";
+        hideError();
+    }
+
+    async function requestResetCode() {
+        hideError();
+        const email = document.getElementById('resetEmail').value;
+        try {
+            const response = await fetch('/api/v1/member/admin/otp/reset-request', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ email: email })
+            });
+            const data = await response.json();
+            if (!response.ok) throw new Error(data.message);
+
+            alert("인증코드가 발송되었습니다.");
+            document.getElementById('reset-request-area').style.display = 'none';
+            document.getElementById('reset-confirm-area').style.display = 'block';
+            document.getElementById('resetCode').focus();
+
+        } catch (e) { showError(e.message); }
+    }
+
+    async function confirmResetCode() {
+        hideError();
+        const email = document.getElementById('resetEmail').value;
+        const code = document.getElementById('resetCode').value;
+        try {
+            const response = await fetch('/api/v1/member/admin/otp/reset-confirm', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ email: email, verificationCode: code })
+            });
+            const data = await response.json();
+            if (!response.ok) throw new Error(data.message);
+
+            alert("초기화 완료! 다시 로그인하면 새로운 QR코드가 생성됩니다.");
+            window.location.reload();
+
+        } catch (e) { showError(e.message); }
+    }
 
     function showError(msg) {
         errorMessageEl.textContent = msg;


### PR DESCRIPTION
커밋 내역을 바탕으로 핵심만 간결하게 정리한 PR 본문입니다. 그대로 복사해서 사용하세요.

---

# 📄 PR 변경사항

@qqee1133 
@lixxce5017 
* **관리자 2단계 인증(Google OTP) 도입**: 보안 강화를 위한 관리자 전용 OTP 로그인 체계 구축
* **데이터 보안 강화**: DB 민감 정보 암/복호화 로직 추가
* **버그 수정**: `main_content` 테이블명 변경에 따른 쿼리 오류 해결
* **UI/UX 개선**: 채팅 목록 내 미디어 메시지 미리보기 텍스트 개선

# 🖌️ 구체적인 구현 내용

* **Google OTP**: `googleauth` 라이브러리를 활용한 검증 로직 구현 및 QR 코드 스캔 UI 추가
* **암호화**: `AttributeConverter`를 상속받은 `StringCryptoConverter`를 통해 엔티티 필드 자동 암/복호화 적용
* **DB**: `AdminOtp` 엔티티 추가 및 Flyway 마이그레이션 스크립트(`Vxx__...`) 작성
* **보안 설정**: OTP 인증 경로(`PermitAll`) 및 암호화 키 환경변수(`yml`) 설정

# ✨개선 사항 및 참고 사항

* 관리자 로그인은 [ID/PW 인증] -> [OTP 검증] 2단계로 분리되어 진행됩니다.
* `main_content` 테이블명 변경 건은 기존 배치 작업 및 검색 쿼리에 모두 반영되었습니다.

# 💯 테스트

* 관리자 로그인 후 QR 등록 및 OTP 번호 일치 여부 확인 완료
* DB 내 암호화 필드(비밀키 등) 정상 저장 및 복호화 조회 확인
* 채팅방 목록 미디어(이미지/동영상) 미리보기 텍스트 정상 출력 확인

# 확인

* [x] 주석 및 print를 제거하셨나요?
* [x] javaDoc을 작성하셨나요?
* [x] merge할 브랜치와 로컬에서 merge 하셨나요?
* [x] 더 수정할 작업은 없는지 확인하셨나요?

---

**도움이 더 필요하신가요?** 예를 들어 특정 에러(예: 42P01)가 이 PR로 해결되었는지 명시하고 싶으시면 말씀해 주세요!