### PR TITLE
새로운 캠페인 전략에 맞게 친구추천 변경 및 고도화 

### DIFF
--- a/src/main/java/core/domain/user/entity/User.java
+++ b/src/main/java/core/domain/user/entity/User.java
@@ -302,4 +302,49 @@ public class User {
     public void changeUserRole(Role role) {
         this.userRole = role;
     }
+    /**
+     * [알고리즘용] 신규 유저 판단 로직
+     * DB의 isNewUser(프로필 설정 여부)와 다르게,
+     * 가입한 지 특정 일수(예: 7일)가 지났는지를 판단합니다.
+     */
+    public boolean isJoinedWithinDays(int days) {
+        if (this.createdAt == null) return false;
+        Instant threshold = Instant.now().minus(days, java.time.temporal.ChronoUnit.DAYS);
+
+        return this.createdAt.isAfter(threshold);
+    }
+
+    /**
+     * [알고리즘용] 유저 활동 점수 (Method B)
+     * 응답률 데이터 부재로 인해 활동 포인트와 방문 횟수를 정규화하여 반환
+     */
+    public double getEngagementScore() {
+        // 예: 활동 포인트 최대 1000점, 방문 횟수 가중치 등 (서비스 규모에 따라 튜닝 필요)
+        double pointScore = (this.activityPoint != null) ? this.activityPoint * 0.5 : 0;
+        double visitScore = (this.visitCount != null) ? this.visitCount * 2.0 : 0;
+        return pointScore + visitScore;
+    }
+    public void incrementVisitCount() {
+        if (this.visitCount == null) {
+            this.visitCount = 0L;
+        }
+        this.visitCount++;
+        touchUpdatedAt(); // 수정 시간 갱신
+    }
+
+    /**
+     * [비즈니스 로직] 활동 포인트 적립
+     * @param points 적립할 점수 (예: 채팅 5점, 좋아요 10점 등)
+     */
+    public void addActivityPoint(Long points) {
+        if (points == null || points <= 0) {
+            return; // 0 이하의 점수는 무시
+        }
+
+        if (this.activityPoint == null) {
+            this.activityPoint = 0L;
+        }
+        this.activityPoint += points;
+        touchUpdatedAt(); // 수정 시간 갱신
+    }
 }

--- a/src/main/java/core/domain/user/entity/User.java
+++ b/src/main/java/core/domain/user/entity/User.java
@@ -107,6 +107,17 @@ public class User {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<UserNotificationSetting> notificationSettings = new ArrayList<>();
 
+    // [추가 1] 활동 포인트 (Method B 구현용)
+    // 접속, 채팅, 좋아요 등을 할 때마다 쌓이는 점수 -> '친절한 유저' 판단 기준
+    @Column(name = "activity_point")
+    private Long activityPoint = 0L;
+
+    @Column(name = "visit_count")
+    private Long visitCount = 0L;
+
+    @Column(name = "reply_rate")
+    private Double replyRate = 0.0;
+
     @Builder
     public User(String firstName,
                 String lastName,

--- a/src/main/java/core/domain/user/repository/UserRepository.java
+++ b/src/main/java/core/domain/user/repository/UserRepository.java
@@ -5,6 +5,7 @@ import core.domain.user.dto.StringCountDto;
 import core.domain.user.entity.User;
 import core.global.enums.Role;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -314,4 +315,24 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
           AND NOT EXISTS (SELECT 1 FROM chat_participant cp WHERE cp.user_id = u.user_id)
     """, nativeQuery = true)
     long countGhostUsers(@Param("start") Instant start, @Param("end") Instant end);
+
+    @Modifying(clearAutomatically = true)
+    @Query(value = """
+        UPDATE users u
+        JOIN (
+            SELECT 
+                cp.user_id,
+                COALESCE(
+                    SUM(CASE WHEN cm.sender_id = cp.user_id THEN 1.0 ELSE 0.0 END) 
+                    / NULLIF(COUNT(cm.message_id), 0)
+                , 0.0) as calculated_rate
+            FROM chat_participant cp
+            JOIN chat_room cr ON cp.chatroom_id = cr.chatroom_id
+            JOIN chat_message cm ON cr.chatroom_id = cm.chatroom_id
+            WHERE cr.is_group = false  -- 1:1 채팅만 반영
+            GROUP BY cp.user_id
+        ) stats ON u.id = stats.user_id
+        SET u.reply_rate = stats.calculated_rate
+    """, nativeQuery = true)
+    void updateReplyRatesBulk();
 }

--- a/src/main/java/core/domain/user/service/ContentBasedRecommender.java
+++ b/src/main/java/core/domain/user/service/ContentBasedRecommender.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.security.SecureRandom;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
@@ -30,13 +31,15 @@ public class ContentBasedRecommender {
     private final FollowRepository followRepository;
     private final ImageService imageService;
     private final SecureRandom secureRandom = new SecureRandom();
-    private static final double WEIGHT_ACTIVITY = 85.0;
-    private static final double WEIGHT_SIMILARITY = 10.0;
-    // 랜덤 비중을 5로 축소 (활동적인 사람이 랜덤 운 때문에 밀려나지 않도록)
-    private static final double WEIGHT_RANDOM = 5.0;
-    // [핵심] 반감기를 '1일'에서 '0.25일(6시간)' 또는 '0.1일(2.4시간)'으로 단축
-    private static final double ACTIVITY_HALF_LIFE_DAYS = 0.1;
 
+    // --- [가중치 설정] 접속 시간과 활동량에 '올인' ---
+    private static final double WEIGHT_RECENCY = 0.6;    // 최근 접속 (60%) - 가장 중요
+    private static final double WEIGHT_ACTIVITY = 0.3;   // 활동량 (30%) - 채팅/방문 많은 사람
+    private static final double WEIGHT_SIMILARITY = 0.1; // 취향/국적 (10%) - 최소한의 필터
+
+    // 활동 포인트 만점 기준 (예: 1000점이면 활동 점수 만점)
+    private static final double MAX_ACTIVITY_POINT = 1000.0;
+    private static final double MAX_VISIT_COUNT = 50.0;
 
     @Transactional(readOnly = true)
     public List<CommendUsersProfileResponse> recommendForUser(Long meId, int limit) {
@@ -44,7 +47,7 @@ public class ContentBasedRecommender {
         User me = userRepository.findById(meId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
-        // 2. 제외 대상 필터링 (팔로잉, 차단, 본인)
+        // 2. 제외 대상 필터링
         List<FollowStatus> statusesToExclude = List.of(FollowStatus.PENDING, FollowStatus.ACCEPTED);
         Set<Long> followingIds = followRepository.findFollowingIdsByUserId(meId, statusesToExclude);
         Set<Long> blockedIds = blockRepository.findAllBlockedUserIds(meId);
@@ -54,38 +57,39 @@ public class ContentBasedRecommender {
         excludeIds.add(meId);
         if (excludeIds.isEmpty()) excludeIds.add(0L);
 
-        Instant activeLimit = Instant.now().minus(3, ChronoUnit.DAYS);
-
+        // [변경] 검색 범위: 최근 24시간 이내 접속자로 제한 (최우선)
+        Instant activeLimit = Instant.now().minus(1, ChronoUnit.DAYS);
         List<User> candidates = userRepository.findActiveCandidates(excludeIds, activeLimit);
-        if (candidates.isEmpty()) {
-            activeLimit = Instant.now().minus(14, ChronoUnit.DAYS);
+
+        // [Fallback] 24시간 이내 접속자가 너무 적으면 최근 3일로 확장
+        if (candidates.size() < 5) {
+            activeLimit = Instant.now().minus(3, ChronoUnit.DAYS);
             candidates = userRepository.findActiveCandidates(excludeIds, activeLimit);
         }
+
         if (candidates.isEmpty()) {
             return List.of();
         }
 
-        // 4. 내 언어/취미 Set으로 변환 (비교 편의성)
+        // 3. 내 취향 정보 준비
         String myCountry = me.getCountry();
         Set<String> myHobbies = csvToSet(me.getHobby());
 
-        // 5. 점수 계산 및 정렬, 상위 3명 추출
+        // 4. 점수 계산 (Recency + Activity 집중)
         List<UserScore> scoredCandidates = candidates.stream()
                 .map(candidate -> {
-                    double score = calculateTotalScore(candidate, myCountry, myHobbies);
+                    double score = calculateScore(candidate, myCountry, myHobbies);
                     return new UserScore(candidate, score);
                 })
-                .sorted(Comparator.comparingDouble(UserScore::getScore).reversed()) // 1. 점수 내림차순 정렬
+                .sorted(Comparator.comparingDouble(UserScore::getScore).reversed())
                 .collect(Collectors.toList());
 
-        // [핵심 변경] 상위 N명을 가져와서 섞음 (Shuffle)
-        // 이유: 활동성 점수가 워낙 강력해서 상위권이 고정되므로, 상위 20명 내에서 랜덤성을 부여
-        int poolSize = Math.min(scoredCandidates.size(), 20); // 상위 20명 (후보가 적으면 전체)
-
+        // 5. 상위권 셔플 (고인물 고착화 방지용 최소한의 셔플)
+        // 점수가 높은 상위 10명 중에서만 랜덤으로 3명을 뽑음
+        int poolSize = Math.min(scoredCandidates.size(), 10);
         List<UserScore> topTierPool = new ArrayList<>(scoredCandidates.subList(0, poolSize));
-        Collections.shuffle(topTierPool); // 여기가 마법의 한 줄 (순서를 뒤섞음)
+        Collections.shuffle(topTierPool, secureRandom);
 
-        // 섞인 목록에서 3명 뽑기
         return topTierPool.stream()
                 .limit(limit)
                 .map(us -> toDto(us.getUser()))
@@ -93,65 +97,78 @@ public class ContentBasedRecommender {
     }
 
     /**
-     * [총점 계산 로직]
-     * Total = (활동성 * 85) + (유사도 * 10) + (랜덤 * 5)
+     * [점수 계산 로직]
+     * Score = (최근접속 * 0.6) + (활동량 * 0.3) + (유사도 * 0.1)
      */
-    private double calculateTotalScore(User candidate, String myCountry, Set<String> myHobbies) {
+    private double calculateScore(User candidate, String myCountry, Set<String> myHobbies) {
+
+        // 1. Recency Score (최근 접속)
+        double recencyScore = calculateRecencyScore(candidate.getLastSeenAt());
+
+        // 2. Activity Score (활동량 - 포인트 + 방문수)
         double activityScore = calculateActivityScore(candidate);
-        // [변경] 파라미터 변경
+
+        // 3. Similarity Score (유사도)
         double similarityScore = calculateSimilarityScore(candidate, myCountry, myHobbies);
-        double randomNoise = secureRandom.nextDouble();
 
-        return (activityScore * WEIGHT_ACTIVITY)
-                + (similarityScore * WEIGHT_SIMILARITY)
-                + (randomNoise * WEIGHT_RANDOM);
+        // 최종 합산
+        return (recencyScore * WEIGHT_RECENCY)
+                + (activityScore * WEIGHT_ACTIVITY)
+                + (similarityScore * WEIGHT_SIMILARITY);
     }
+
     /**
-     * [활동성 점수] 0.0 ~ 1.0
-     * 최근 접속일수록 1.0에 가까움. 시간이 지날수록 지수적으로 감소.
+     * [최근 접속 점수]
+     * 10분 이내 접속 시 1.0 (초강력), 시간이 지날수록 급격히 하락
      */
-    private double calculateActivityScore(User user) {
-        if (user.getLastSeenAt() == null) return 0.0;
+    private double calculateRecencyScore(Instant lastSeenAt) {
+        if (lastSeenAt == null) return 0.0;
 
-        long hoursSinceLastSeen = ChronoUnit.HOURS.between(user.getLastSeenAt(), Instant.now());
-        // 미래 시간인 경우 방어 로직
-        if (hoursSinceLastSeen < 0) hoursSinceLastSeen = 0;
+        long minutesAgo = Duration.between(lastSeenAt, Instant.now()).toMinutes();
+        if (minutesAgo <= 10) return 1.0; // 방금 접속한 사람 최고 우대
+        if (minutesAgo <= 60) return 0.9; // 1시간 이내
 
-        double daysSince = hoursSinceLastSeen / 24.0;
-        double decayRate = Math.log(2) / ACTIVITY_HALF_LIFE_DAYS;
-
-        return Math.exp(-decayRate * daysSince);
+        // 24시간(1440분)이 지나면 점수가 0에 가깝게 떨어짐
+        return Math.exp(-((double) minutesAgo / 1440.0));
     }
 
     /**
-     * [유사도 점수] 0.0 ~ 1.0
-     * 국적(2.0) + 취미(1.0) 가중치 적용
+     * [활동량 점수]
+     * 채팅 포인트(ActivityPoint)와 방문 횟수(VisitCount)를 반영
+     */
+    private double calculateActivityScore(User u) {
+        long points = (u.getActivityPoint() != null) ? u.getActivityPoint() : 0L;
+        long visits = (u.getVisitCount() != null) ? u.getVisitCount() : 0L;
+
+        // 포인트 점수 (최대 1.0)
+        double pScore = Math.min(points / MAX_ACTIVITY_POINT, 1.0);
+
+        // 방문 점수 (최대 1.0)
+        double vScore = Math.min(visits / MAX_VISIT_COUNT, 1.0);
+
+        // 활동 포인트(채팅)에 더 가중치 (7:3)
+        return (pScore * 0.7) + (vScore * 0.3);
+    }
+
+    /**
+     * [유사도 점수] - 보조 지표
      */
     private double calculateSimilarityScore(User candidate, String myCountry, Set<String> myHobbies) {
-        // 1. 국적 점수 계산 (가중치 2.0)
-        // 국적이 같으면 2점, 다르면 0점
-        double countryScore = 0.0;
+        double score = 0.0;
+        // 국적 같으면 0.5
         if (myCountry != null && myCountry.equalsIgnoreCase(candidate.getCountry())) {
-            countryScore = 2.0;
+            score += 0.5;
         }
-
-        // 2. 취미 점수 계산 (가중치 1.0)
-        // 일치하는 취미 개수 * 1.0
+        // 취미 겹치면 0.5 (개수 무관, 하나라도 겹치면)
         Set<String> candidateHobbies = csvToSet(candidate.getHobby());
-        long hobbyMatchCount = candidateHobbies.stream()
-                .filter(myHobbies::contains).count();
-        double hobbyScore = hobbyMatchCount * 1.0;
-
-        // 3. 정규화 (0.0 ~ 1.0 사이 값으로 변환)
-        // 분모 = 국적 만점(2.0) + 내 취미 개수(다 맞았을 때)
-        double maxPossibleScore = 2.0 + Math.max(1, myHobbies.size());
-
-        double totalScore = countryScore + hobbyScore;
-
-        return Math.min(1.0, totalScore / maxPossibleScore);
+        boolean hasCommonHobby = candidateHobbies.stream().anyMatch(myHobbies::contains);
+        if (hasCommonHobby) {
+            score += 0.5;
+        }
+        return score;
     }
-    // --- Helper Methods ---
 
+    // --- Helper Methods ---
     private Set<String> csvToSet(String csv) {
         if (csv == null || csv.isBlank()) return Set.of();
         return Arrays.stream(csv.split(","))
@@ -170,7 +187,6 @@ public class ContentBasedRecommender {
         );
     }
 
-    // 내부 점수 래퍼 클래스
     @lombok.AllArgsConstructor
     @lombok.Getter
     private static class UserScore {

--- a/src/main/java/core/domain/user/service/ContentBasedRecommender.java
+++ b/src/main/java/core/domain/user/service/ContentBasedRecommender.java
@@ -133,23 +133,21 @@ public class ContentBasedRecommender {
     }
 
     /**
-     * [활동량 점수]
-     * 채팅 포인트(ActivityPoint)와 방문 횟수(VisitCount)를 반영
+     * [활동성 점수 계산 - 최종판]
+     * 1. 응답률 (Quality): 답장을 잘 해주는가? (40%)
+     * 2. 활동 포인트 (Quantity): 채팅을 많이 치는가? (30%)
+     * 3. 방문 횟수 (Frequency): 자주 오는가? (30%)
      */
     private double calculateActivityScore(User u) {
+        double rate = (u.getReplyRate() != null) ? u.getReplyRate() : 0.5;
+
         long points = (u.getActivityPoint() != null) ? u.getActivityPoint() : 0L;
+        double pointScore = Math.min(points / 1000.0, 1.0);
         long visits = (u.getVisitCount() != null) ? u.getVisitCount() : 0L;
+        double visitScore = Math.min(visits / 50.0, 1.0);
 
-        // 포인트 점수 (최대 1.0)
-        double pScore = Math.min(points / MAX_ACTIVITY_POINT, 1.0);
-
-        // 방문 점수 (최대 1.0)
-        double vScore = Math.min(visits / MAX_VISIT_COUNT, 1.0);
-
-        // 활동 포인트(채팅)에 더 가중치 (7:3)
-        return (pScore * 0.7) + (vScore * 0.3);
+        return (rate * 0.4) + (pointScore * 0.3) + (visitScore * 0.3);
     }
-
     /**
      * [유사도 점수] - 보조 지표
      */

--- a/src/main/java/core/domain/user/service/UserActivityService.java
+++ b/src/main/java/core/domain/user/service/UserActivityService.java
@@ -34,4 +34,20 @@ public class UserActivityService {
             }
         });
     }
+    @Transactional
+    public void recordVisit(Long userId) {
+        userRepository.findById(userId).ifPresent(user -> {
+            // 마지막 접속이 오늘 이전이라면(혹은 1시간 전) 방문 횟수 증가 로직 등 추가 가능
+            // 여기서는 심플하게 접속 시 무조건 증가 (필요시 시간 체크 로직 추가)
+            user.incrementVisitCount();
+            user.updateLastSeenAt();
+        });
+    }
+
+    @Transactional
+    public void addActivityPoint(Long userId, long points) {
+        userRepository.findById(userId).ifPresent(user -> {
+            user.addActivityPoint(points);
+        });
+    }
 }

--- a/src/main/java/core/domain/user/service/UserMetricsScheduler.java
+++ b/src/main/java/core/domain/user/service/UserMetricsScheduler.java
@@ -1,0 +1,37 @@
+package core.domain.user.service;
+
+
+import core.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserMetricsScheduler {
+
+    private final UserRepository userRepository;
+
+    /**
+     * 매일 새벽 4시에 전체 유저의 응답률(reply_rate)을 갱신합니다.
+     * 트래픽이 가장 적은 시간에 수행하여 DB 부하를 최소화합니다.
+     */
+    @Scheduled(cron = "0 0 4 * * *")
+    @Transactional
+    public void updateAllUserReplyRates() {
+        log.info("=== [Scheduler] 유저 응답률(Reply Rate) 계산 시작 ===");
+        long start = System.currentTimeMillis();
+
+        try {
+            userRepository.updateReplyRatesBulk();
+        } catch (Exception e) {
+            log.error("응답률 갱신 중 오류 발생", e);
+        }
+
+        long end = System.currentTimeMillis();
+        log.info("=== [Scheduler] 유저 응답률 계산 완료 (소요시간: {}ms) ===", (end - start));
+    }
+}

--- a/src/main/java/core/global/config/UserActivityInterceptor.java
+++ b/src/main/java/core/global/config/UserActivityInterceptor.java
@@ -18,6 +18,7 @@ public class UserActivityInterceptor implements HandlerInterceptor {
     @Override
     public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
         if (authentication != null && authentication.isAuthenticated() && !"anonymousUser".equals(authentication.getPrincipal())) {
             String userEmail = authentication.getName();
             userActivityService.updateLastSeenAt(userEmail);

--- a/src/main/java/core/global/websocket/config/StompChannelInterceptor.java
+++ b/src/main/java/core/global/websocket/config/StompChannelInterceptor.java
@@ -32,11 +32,13 @@ public class StompChannelInterceptor implements ChannelInterceptor {
     private final UserActivityService userActivityService;
     private final ChatRoomDwellRecorder dwell;
     private final ChatMetrics chatMetrics;
+
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
         log.debug("preSend 진입: command={}, destination={}", accessor.getCommand(), accessor.getDestination());
 
+        // 1. CONNECT (연결 시)
         if (StompCommand.CONNECT.equals(accessor.getCommand())) {
             log.info("STOMP CONNECT 요청 처리 시작");
             String authHeader = accessor.getFirstNativeHeader("Authorization");
@@ -68,8 +70,12 @@ public class StompChannelInterceptor implements ChannelInterceptor {
                     sessionAttributes.put("userAuth", auth);
                     sessionAttributes.put("userId", userId);
                     sessionAttributes.put("connectAt", System.currentTimeMillis());
+
                     String userEmail = auth.getName();
-                    userActivityService.updateLastSeenAt(userEmail);
+                    userActivityService.updateLastSeenAt(userEmail); // 기존: 휴면 복구 및 접속 시간 갱신
+
+                    // [추가 1] 방문 횟수 증가 (Visit Count)
+                    userActivityService.recordVisit(userId);
                 }
                 accessor.setUser(auth);
                 log.info("STOMP JWT 인증 완료: WebSocket 세션에 사용자 정보 등록 (userId: {})", userId);
@@ -78,20 +84,31 @@ public class StompChannelInterceptor implements ChannelInterceptor {
 
             } catch (Exception e) {
                 log.error("STOMP JWT 처리 중 예외 발생: {}", e.getMessage(), e);
-
                 chatMetrics.onWsConnect("auth_error");
-
                 throw new BadCredentialsException(AuthErrorCode.JWT_TOKEN_INVALID.getMessage());
             }
 
-        } else if (StompCommand.SEND.equals(accessor.getCommand()) || StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
+        }
+        // 2. SEND (메시지 전송 시)
+        else if (StompCommand.SEND.equals(accessor.getCommand())) {
 
-            if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
-                String sessionId = accessor.getSessionId();
-                String dest = accessor.getDestination();
-                String roomId = parseRoomId(dest);
-                dwell.onEnter(sessionId, roomId);
+            // [추가 2] 채팅 메시지 전송 시 활동 포인트 적립
+            Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+            if (sessionAttributes != null) {
+                Long userId = (Long) sessionAttributes.get("userId");
+                if (userId != null) {
+                    // 채팅 1회당 5점 부여 (정책에 따라 조절)
+                    userActivityService.addActivityPoint(userId, 5L);
+                }
             }
+
+        }
+        // 3. SUBSCRIBE (채팅방 입장 시)
+        else if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
+            String sessionId = accessor.getSessionId();
+            String dest = accessor.getDestination();
+            String roomId = parseRoomId(dest);
+            dwell.onEnter(sessionId, roomId);
 
         } else if (StompCommand.DISCONNECT.equals(accessor.getCommand())) {
 

--- a/src/main/resources/db/migration/V202601051145__create_main_content_search_custom_function.sql
+++ b/src/main/resources/db/migration/V202601051145__create_main_content_search_custom_function.sql
@@ -1,15 +1,15 @@
-CREATE OR REPLACE FUNCTION clean_html_for_search(content text)
-RETURNS text AS $$
-BEGIN
-    IF content IS NULL THEN RETURN ''; END IF;
-    -- 1. HTML 태그 제거
-    content := regexp_replace(content, '<[^>]*>', ' ', 'g');
-    -- 2. URL 제거
-    content := regexp_replace(content, '(http|https|ftp)://[^\s/$.?#].[^\s]*', ' ', 'g');
-RETURN trim(regexp_replace(content, '\s+', ' ', 'g'));
-END;
-$$ LANGUAGE plpgsql IMMUTABLE;
+    CREATE OR REPLACE FUNCTION clean_html_for_search(content text)
+    RETURNS text AS $$
+    BEGIN
+        IF content IS NULL THEN RETURN ''; END IF;
+        -- 1. HTML 태그 제거
+        content := regexp_replace(content, '<[^>]*>', ' ', 'g');
+        -- 2. URL 제거
+        content := regexp_replace(content, '(http|https|ftp)://[^\s/$.?#].[^\s]*', ' ', 'g');
+    RETURN trim(regexp_replace(content, '\s+', ' ', 'g'));
+    END;
+    $$ LANGUAGE plpgsql IMMUTABLE;
 
--- 기존 인덱스가 있다면 삭제 후 생성
-CREATE INDEX idx_main_page_content_pgroonga ON main_page_content
-    USING pgroonga (content_id, title, (clean_html_for_search(html_content)));
+    -- 기존 인덱스가 있다면 삭제 후 생성
+    CREATE INDEX idx_main_page_content_pgroonga ON main_page_content
+        USING pgroonga (content_id, title, (clean_html_for_search(html_content)));

--- a/src/main/resources/db/migration/V202601110224__add_user_activity_metrics.sql
+++ b/src/main/resources/db/migration/V202601110224__add_user_activity_metrics.sql
@@ -1,0 +1,11 @@
+-- 1. 활동 포인트 (친절한 유저 판단 기준)
+ALTER TABLE users
+    ADD COLUMN activity_point BIGINT DEFAULT 0;
+
+-- 2. 방문 횟수
+ALTER TABLE users
+    ADD COLUMN visit_count BIGINT DEFAULT 0;
+
+-- 3. 응답률 (소수점 지원)
+ALTER TABLE users
+    ADD COLUMN reply_rate DOUBLE DEFAULT 0.0;


### PR DESCRIPTION
제공해주신 템플릿에 맞춰 작성한 **PR 내용**입니다.
복사해서 바로 사용하시면 됩니다!

---

# 📄 PR 변경사항

* **User 도메인**: `User` 엔티티에 응답률(`replyRate`) 필드 추가 및 벌크 업데이트 쿼리 구현
* **스케줄러**: 매일 새벽 전 유저의 응답률을 계산하는 `UserMetricsScheduler` 구현
* **추천 시스템**: `ContentBasedRecommender` 알고리즘에 응답률 가중치 반영 및 로직 고도화

# 🖌️ 구체적인 구현 내용

**1. 유저 응답률(Reply Rate) 분석 스케줄러 구현**

* **고려 사항**: 실시간으로 응답률을 계산하면 채팅 전송 시마다 쿼리가 발생하여 DB 부하가 큽니다. 이를 방지하기 위해 **매일 새벽 4시**에 스케줄러가 일괄 처리하도록 구현했습니다.
* **계산 로직**: `(내가 보낸 메시지) / (전체 메시지)` 공식을 사용하되, **1:1 채팅방(`is_group = false`)** 데이터만 집계하여 실질적인 소통 능력을 평가합니다.
* **성능 최적화**: JPA Dirty Checking 대신 `Native Query`를 사용한 Bulk Update로 대용량 데이터 처리에 최적화했습니다.

**2. 추천 알고리즘 가중치 재설계 (Activity Score)**

* 기존의 단순 활동량(채팅 수) 위주 추천에서 **'소통의 질'**을 평가하도록 변경했습니다.
* **변경 전**: 활동 포인트(70%) + 방문 횟수(30%)
* **변경 후**: **응답률(40%)** + 활동 포인트(30%) + 방문 횟수(30%)
* **효과**: 단순히 메시지를 많이 보내는 유저보다, **답장을 잘 해주는 친절한 유저**가 상위에 노출됩니다.

# ✨개선 사항 및 참고 사항

* `User` 테이블에 `reply_rate` 컬럼이 추가되었습니다. (기본값 `NULL`)
* 신규 유저나 데이터가 없는 경우 응답률 점수는 **0.5(중간값)**로 보정하여 불이익을 방지했습니다.
* 스케줄러는 `@Scheduled(cron = "0 0 4 * * *")`로 설정되어 있습니다. 테스트 시 시간을 조정하거나 메서드를 직접 호출해야 합니다.

# 💯 테스트
<img width="1852" height="556" alt="image" src="https://github.com/user-attachments/assets/8248bd89-da4f-4777-a731-abe5d2431b62" />
로컬 플라이웨이가 현재 문제라 테스트서버에서 플라이웨이 테스트 및 추천,그리고 인터셉터들이 문제없이 작동하는지 확인하겠습니다

# 확인

* [ ] 주석 및 print를 제거하셨나요?
* [ ] javaDoc을 작성하셨나요?
* [ ] merge할 브랜치와 로컬에서 merge 하셨나요?
* [ ] 더 수정할 작업은 없는지 확인하셨나요?